### PR TITLE
Export DoRequest and DoGraphQL for external use

### DIFF
--- a/appie_test.go
+++ b/appie_test.go
@@ -127,7 +127,7 @@ func TestAutoRefreshOnExpiredToken(t *testing.T) {
 
 	ctx := context.Background()
 	var result map[string]string
-	if err := client.doRequest(ctx, http.MethodGet, "/test-endpoint", nil, &result); err != nil {
+	if err := client.DoRequest(ctx, http.MethodGet, "/test-endpoint", nil, &result); err != nil {
 		t.Fatal(err)
 	}
 
@@ -189,7 +189,7 @@ func TestNoAutoRefreshWhenNotExpired(t *testing.T) {
 
 	ctx := context.Background()
 	var result map[string]string
-	if err := client.doRequest(ctx, http.MethodGet, "/test-endpoint", nil, &result); err != nil {
+	if err := client.DoRequest(ctx, http.MethodGet, "/test-endpoint", nil, &result); err != nil {
 		t.Fatal(err)
 	}
 

--- a/auth.go
+++ b/auth.go
@@ -24,7 +24,7 @@ func (c *Client) exchangeCode(ctx context.Context, code string) error {
 	}
 
 	var tok token
-	if err := c.doRequest(ctx, http.MethodPost, "/mobile-auth/v1/auth/token", body, &tok); err != nil {
+	if err := c.DoRequest(ctx, http.MethodPost, "/mobile-auth/v1/auth/token", body, &tok); err != nil {
 		return fmt.Errorf("failed to exchange code: %w", err)
 	}
 
@@ -57,7 +57,7 @@ func (c *Client) refreshAccessToken(ctx context.Context) error {
 	}
 
 	var tok token
-	if err := c.doRequest(ctx, http.MethodPost, "/mobile-auth/v1/auth/token/refresh", body, &tok); err != nil {
+	if err := c.DoRequest(ctx, http.MethodPost, "/mobile-auth/v1/auth/token/refresh", body, &tok); err != nil {
 		return fmt.Errorf("failed to refresh token: %w", err)
 	}
 
@@ -80,7 +80,7 @@ func (c *Client) GetAnonymousToken(ctx context.Context) error {
 	}
 
 	var tok token
-	if err := c.doRequest(ctx, http.MethodPost, "/mobile-auth/v1/auth/token/anonymous", body, &tok); err != nil {
+	if err := c.DoRequest(ctx, http.MethodPost, "/mobile-auth/v1/auth/token/anonymous", body, &tok); err != nil {
 		return fmt.Errorf("failed to get anonymous token: %w", err)
 	}
 

--- a/bonus.go
+++ b/bonus.go
@@ -77,7 +77,7 @@ func (c *Client) getBonusMetadata(ctx context.Context) ([]string, error) {
 	path := "/mobile-services/bonuspage/v3/metadata"
 
 	var result bonusMetadataResponse
-	if err := c.doRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
+	if err := c.DoRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
 		return nil, fmt.Errorf("get bonus metadata failed: %w", err)
 	}
 
@@ -105,7 +105,7 @@ func (c *Client) getBonusSection(ctx context.Context, category string) ([]Produc
 	path := "/mobile-services/bonuspage/v2/section?" + params.Encode()
 
 	var result bonusSectionResponse
-	if err := c.doRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
+	if err := c.DoRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
 		return nil, fmt.Errorf("get bonus products failed (category=%s): %w", category, err)
 	}
 
@@ -152,7 +152,7 @@ func (c *Client) GetSpotlightBonusProducts(ctx context.Context) ([]Product, erro
 	path := "/mobile-services/bonuspage/v2/section/spotlight?" + params.Encode()
 
 	var result bonusSectionResponse
-	if err := c.doRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
+	if err := c.DoRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
 		return nil, fmt.Errorf("get spotlight bonus products failed: %w", err)
 	}
 
@@ -299,7 +299,7 @@ func (p *bonusGraphQLProduct) toProduct() Product {
 func (c *Client) getBonusPeriod(ctx context.Context) (startDate, endDate string, err error) {
 	path := "/mobile-services/bonuspage/v3/metadata"
 	var result bonusMetadataResponse
-	if err := c.doRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
+	if err := c.DoRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
 		return "", "", fmt.Errorf("get bonus period failed: %w", err)
 	}
 	if len(result.Periods) == 0 {
@@ -332,7 +332,7 @@ func (c *Client) GetBonusGroupProducts(ctx context.Context, segmentID string) ([
 	}
 
 	var resp bonusGroupProductsResponse
-	if err := c.doGraphQL(ctx, fetchBonusGroupProductsQuery, variables, &resp); err != nil {
+	if err := c.DoGraphQL(ctx, fetchBonusGroupProductsQuery, variables, &resp); err != nil {
 		return nil, fmt.Errorf("get bonus group products failed: %w", err)
 	}
 

--- a/client.go
+++ b/client.go
@@ -207,8 +207,8 @@ func (c *Client) ensureFreshToken(ctx context.Context, path string) {
 	}
 }
 
-// doRequest performs an HTTP request and decodes the response.
-func (c *Client) doRequest(ctx context.Context, method, path string, body, result any) error {
+// DoRequest performs an HTTP request and decodes the response.
+func (c *Client) DoRequest(ctx context.Context, method, path string, body, result any) error {
 	c.ensureFreshToken(ctx, path)
 
 	var bodyReader io.Reader
@@ -254,15 +254,15 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body, resul
 	return nil
 }
 
-// doGraphQL performs a GraphQL request.
-func (c *Client) doGraphQL(ctx context.Context, query string, variables map[string]any, result any) error {
+// DoGraphQL performs a GraphQL request.
+func (c *Client) DoGraphQL(ctx context.Context, query string, variables map[string]any, result any) error {
 	req := graphQLRequest{
 		Query:     query,
 		Variables: variables,
 	}
 
 	var resp graphQLResponse[json.RawMessage]
-	if err := c.doRequest(ctx, http.MethodPost, "/graphql", req, &resp); err != nil {
+	if err := c.DoRequest(ctx, http.MethodPost, "/graphql", req, &resp); err != nil {
 		return err
 	}
 

--- a/member.go
+++ b/member.go
@@ -78,7 +78,7 @@ type memberResponse struct {
 // loyalty cards (Bonus, Gall & Gall), and customer segmentation data.
 func (c *Client) GetMember(ctx context.Context) (*Member, error) {
 	var resp memberResponse
-	if err := c.doGraphQL(ctx, fetchMemberQuery, nil, &resp); err != nil {
+	if err := c.DoGraphQL(ctx, fetchMemberQuery, nil, &resp); err != nil {
 		return nil, fmt.Errorf("get member failed: %w", err)
 	}
 

--- a/order.go
+++ b/order.go
@@ -75,7 +75,7 @@ func (r *orderSummaryResponse) toOrder() Order {
 // The order ID is cached for use in subsequent order operations.
 func (c *Client) GetOrder(ctx context.Context) (*Order, error) {
 	var result orderSummaryResponse
-	if err := c.doRequest(ctx, http.MethodGet, "/mobile-services/order/v1/summaries/active?sortBy=DEFAULT", nil, &result); err != nil {
+	if err := c.DoRequest(ctx, http.MethodGet, "/mobile-services/order/v1/summaries/active?sortBy=DEFAULT", nil, &result); err != nil {
 		return nil, fmt.Errorf("get order failed: %w", err)
 	}
 
@@ -134,7 +134,7 @@ func (c *Client) AddToOrder(ctx context.Context, items []OrderItem) error {
 		"items": reqItems,
 	}
 
-	if err := c.doRequest(ctx, http.MethodPut, "/mobile-services/order/v1/items?sortBy=DEFAULT", body, nil); err != nil {
+	if err := c.DoRequest(ctx, http.MethodPut, "/mobile-services/order/v1/items?sortBy=DEFAULT", body, nil); err != nil {
 		return fmt.Errorf("add to order failed: %w", err)
 	}
 
@@ -173,7 +173,7 @@ func (c *Client) ClearOrder(ctx context.Context) error {
 // GetOrderSummary retrieves the order summary/totals.
 func (c *Client) GetOrderSummary(ctx context.Context) (*OrderSummary, error) {
 	var result orderSummaryResponse
-	if err := c.doRequest(ctx, http.MethodGet, "/mobile-services/order/v1/summaries/active?sortBy=DEFAULT", nil, &result); err != nil {
+	if err := c.DoRequest(ctx, http.MethodGet, "/mobile-services/order/v1/summaries/active?sortBy=DEFAULT", nil, &result); err != nil {
 		return nil, fmt.Errorf("get order summary failed: %w", err)
 	}
 
@@ -203,7 +203,7 @@ func (c *Client) ReopenOrder(ctx context.Context, orderID int) error {
 
 	var resp reopenResponse
 	vars := map[string]any{"id": orderID}
-	if err := c.doGraphQL(ctx, reopenOrderMutation, vars, &resp); err != nil {
+	if err := c.DoGraphQL(ctx, reopenOrderMutation, vars, &resp); err != nil {
 		return fmt.Errorf("reopen order failed: %w", err)
 	}
 
@@ -233,7 +233,7 @@ func (c *Client) RevertOrder(ctx context.Context, orderID int) error {
 
 	var resp revertResponse
 	vars := map[string]any{"id": orderID}
-	if err := c.doGraphQL(ctx, revertOrderMutation, vars, &resp); err != nil {
+	if err := c.DoGraphQL(ctx, revertOrderMutation, vars, &resp); err != nil {
 		return fmt.Errorf("revert order failed: %w", err)
 	}
 
@@ -326,7 +326,7 @@ type fulfillmentResult struct {
 // These are orders that have been submitted and are awaiting delivery.
 func (c *Client) GetFulfillments(ctx context.Context) ([]Fulfillment, error) {
 	var resp fulfillmentsResponse
-	if err := c.doGraphQL(ctx, fulfillmentsQuery, nil, &resp); err != nil {
+	if err := c.DoGraphQL(ctx, fulfillmentsQuery, nil, &resp); err != nil {
 		return nil, fmt.Errorf("get fulfillments failed: %w", err)
 	}
 

--- a/products.go
+++ b/products.go
@@ -133,7 +133,7 @@ func (c *Client) SearchProducts(ctx context.Context, query string, limit int) ([
 	path := "/mobile-services/product/search/v2?" + params.Encode()
 
 	var result searchResponse
-	if err := c.doRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
+	if err := c.DoRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
 		return nil, fmt.Errorf("search products failed: %w", err)
 	}
 
@@ -155,7 +155,7 @@ func (c *Client) GetProduct(ctx context.Context, productID int) (*Product, error
 		ProductCard productResponse `json:"productCard"`
 	}
 
-	if err := c.doRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
+	if err := c.DoRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
 		return nil, fmt.Errorf("get product failed: %w", err)
 	}
 
@@ -187,7 +187,7 @@ func (c *Client) fetchNutritionalInfo(ctx context.Context, productID int) ([]Nut
 	}
 
 	var resp productNutritionResponse
-	if err := c.doGraphQL(ctx, fetchProductNutritionQuery, variables, &resp); err != nil {
+	if err := c.DoGraphQL(ctx, fetchProductNutritionQuery, variables, &resp); err != nil {
 		return nil, err
 	}
 
@@ -227,7 +227,7 @@ func (c *Client) GetProductsByIDs(ctx context.Context, productIDs []int) ([]Prod
 	var result struct {
 		Products []productResponse `json:"products"`
 	}
-	if err := c.doRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
+	if err := c.DoRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
 		return nil, fmt.Errorf("get products by ids failed: %w", err)
 	}
 

--- a/receipts.go
+++ b/receipts.go
@@ -40,7 +40,7 @@ type receiptItemDetail struct {
 // GetReceipts retrieves the list of in-store receipts (kassabonnen) for the authenticated user.
 func (c *Client) GetReceipts(ctx context.Context) ([]Receipt, error) {
 	var result receiptsResponse
-	if err := c.doRequest(ctx, http.MethodGet, "/mobile-services/v1/receipts", nil, &result); err != nil {
+	if err := c.DoRequest(ctx, http.MethodGet, "/mobile-services/v1/receipts", nil, &result); err != nil {
 		return nil, fmt.Errorf("get receipts failed: %w", err)
 	}
 
@@ -63,7 +63,7 @@ func (c *Client) GetReceipt(ctx context.Context, transactionID string) (*Receipt
 	path := fmt.Sprintf("/mobile-services/v2/receipts/%s", transactionID)
 
 	var result receiptDetailResponse
-	if err := c.doRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
+	if err := c.DoRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
 		return nil, fmt.Errorf("get receipt failed: %w", err)
 	}
 

--- a/shoppinglist.go
+++ b/shoppinglist.go
@@ -41,7 +41,7 @@ func (c *Client) GetShoppingLists(ctx context.Context, productID int) ([]Shoppin
 	path := fmt.Sprintf("/mobile-services/lists/v3/lists?productId=%d", productID)
 
 	var result []listResponse
-	if err := c.doRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
+	if err := c.DoRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
 		return nil, fmt.Errorf("get shopping lists failed: %w", err)
 	}
 
@@ -98,7 +98,7 @@ func (c *Client) AddToShoppingList(ctx context.Context, items []ListItem) error 
 		"items": v2Items,
 	}
 
-	if err := c.doRequest(ctx, http.MethodPatch, "/mobile-services/shoppinglist/v2/items", body, nil); err != nil {
+	if err := c.DoRequest(ctx, http.MethodPatch, "/mobile-services/shoppinglist/v2/items", body, nil); err != nil {
 		return fmt.Errorf("add to shopping list failed: %w", err)
 	}
 
@@ -149,7 +149,7 @@ func (c *Client) AddToFavoriteList(ctx context.Context, listID string, productID
 		} `json:"favoriteListProductsAddV2"`
 	}
 
-	if err := c.doGraphQL(ctx, mutation, variables, &result); err != nil {
+	if err := c.DoGraphQL(ctx, mutation, variables, &result); err != nil {
 		return fmt.Errorf("add to favorite list failed: %w", err)
 	}
 
@@ -163,7 +163,7 @@ func (c *Client) AddToFavoriteList(ctx context.Context, listID string, productID
 // RemoveFromShoppingList removes an item from the shopping list.
 func (c *Client) RemoveFromShoppingList(ctx context.Context, itemID string) error {
 	path := fmt.Sprintf("/mobile-services/lists/v3/lists/items/%s", itemID)
-	if err := c.doRequest(ctx, http.MethodDelete, path, nil, nil); err != nil {
+	if err := c.DoRequest(ctx, http.MethodDelete, path, nil, nil); err != nil {
 		return fmt.Errorf("remove from shopping list failed: %w", err)
 	}
 
@@ -178,7 +178,7 @@ func (c *Client) CheckShoppingListItem(ctx context.Context, itemID string, check
 	}
 
 	path := fmt.Sprintf("/mobile-services/lists/v3/lists/items/%s", itemID)
-	if err := c.doRequest(ctx, http.MethodPatch, path, body, nil); err != nil {
+	if err := c.DoRequest(ctx, http.MethodPatch, path, body, nil); err != nil {
 		return fmt.Errorf("check shopping list item failed: %w", err)
 	}
 


### PR DESCRIPTION
The library wraps common AH API calls but callers frequently need endpoints that aren't wrapped yet — e.g. GraphQL receipts (the REST receipt endpoints are down), productConvertId, recipe search, or category browsing.

Exporting these two methods lets callers make arbitrary API calls while reusing the client's auth, headers, token refresh, and custom HTTP client injection.