### PR TITLE
Order & shopping list CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,14 +104,24 @@ Usage:
 # Login to Albert Heijn (opens browser for OAuth)
 appie login
 
-# List recent receipts
-appie receipt
+# Search products
+appie search "pindakaas"
 
-# List last 5 receipts
-appie receipt -n 5
+# Receipts
+appie receipt                          # list recent receipts
+appie receipt show <transaction-id>    # show items, discounts, payment
 
-# Show receipt details (items, discounts, payment)
-appie receipt <transaction-id>
+# Orders
+appie order                            # list open orders
+appie order show <order-id>            # show order contents
+appie order add <order-id> <product>   # add product (by ID or search term)
+appie order rm <order-id> <product-id> # remove product
+
+# Shopping lists
+appie list                             # list all shopping lists
+appie list show <list-id>              # show items in a list
+appie list add <list-id> <product>     # add product (by ID or search term)
+appie list rm <list-id> <product-id>   # remove product
 ```
 
 Config is stored at `~/.config/appie/config.json` (or `$XDG_CONFIG_HOME/appie/config.json`). Override with `-c`.

--- a/appie_integration_test.go
+++ b/appie_integration_test.go
@@ -145,6 +145,36 @@ func TestGetShoppingList(t *testing.T) {
 	}
 }
 
+func TestGetShoppingListItems(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	lists, err := client.GetShoppingLists(ctx, 0)
+	if err != nil {
+		t.Fatalf("failed to get shopping lists: %v", err)
+	}
+	if len(lists) == 0 {
+		t.Skip("no shopping lists found")
+	}
+
+	for _, list := range lists {
+		t.Logf("List: %s (%s, %d items)", list.Name, list.ID, list.ItemCount)
+
+		items, err := client.GetShoppingListItems(ctx, list.ID)
+		if err != nil {
+			t.Fatalf("failed to get items for list %s: %v", list.Name, err)
+		}
+
+		for i, item := range items {
+			if i >= 5 {
+				t.Logf("  ... and %d more", len(items)-5)
+				break
+			}
+			t.Logf("  - [%s] productId=%d qty=%d", item.ID, item.ProductID, item.Quantity)
+		}
+	}
+}
+
 func TestOrderRoundTrip(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()

--- a/bonus.go
+++ b/bonus.go
@@ -42,22 +42,13 @@ type bonusGroupResponse struct {
 	SegmentDescription  string            `json:"segmentDescription"`
 	DiscountDescription string            `json:"discountDescription"`
 	Category            string            `json:"category"`
-	Images              []imageResponse   `json:"images"`
+	Images              []Image           `json:"images"`
 	Products            []productResponse `json:"products"`
 	ExampleFromPrice    float64           `json:"exampleFromPrice"`
 	ExampleForPrice     float64           `json:"exampleForPrice"`
 }
 
 func (bg *bonusGroupResponse) toProduct() Product {
-	var images []Image
-	for _, img := range bg.Images {
-		images = append(images, Image{
-			URL:    img.URL,
-			Width:  img.Width,
-			Height: img.Height,
-		})
-	}
-
 	return Product{
 		Title:          bg.SegmentDescription,
 		Category:       bg.Category,
@@ -68,7 +59,7 @@ func (bg *bonusGroupResponse) toProduct() Product {
 			Now: bg.ExampleForPrice,
 			Was: bg.ExampleFromPrice,
 		},
-		Images: images,
+		Images: bg.Images,
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -15,9 +15,9 @@ import (
 )
 
 const (
-	defaultBaseURL    = "https://api.ah.nl"
-	defaultUserAgent  = "Appie/9.28 (iPhone17,3; iPhone; CPU OS 26_1 like Mac OS X)"
-	defaultClientID   = "appie-ios"
+	defaultBaseURL       = "https://api.ah.nl"
+	defaultUserAgent     = "Appie/9.28 (iPhone17,3; iPhone; CPU OS 26_1 like Mac OS X)"
+	defaultClientID      = "appie-ios"
 	defaultClientVersion = "9.28"
 )
 
@@ -26,10 +26,10 @@ const (
 //
 // Client is safe for concurrent use. Token state is protected by a mutex.
 type Client struct {
-	httpClient *http.Client
-	baseURL    string
-	userAgent  string
-	clientID   string
+	httpClient    *http.Client
+	baseURL       string
+	userAgent     string
+	clientID      string
 	clientVersion string
 
 	mu           sync.RWMutex
@@ -37,11 +37,11 @@ type Client struct {
 	refreshToken string
 	memberID     string
 	expiresAt    time.Time
-	orderID      string
+	orderID      string // sent as appie-current-order-id header, mirroring the iOS app; the API may use this (not server-side state) to determine the active order
 	orderHash    string
 
 	configPath   string
-	loginBaseURL string      // overridable for testing; defaults to "https://login.ah.nl"
+	loginBaseURL string       // overridable for testing; defaults to "https://login.ah.nl"
 	openBrowser  func(string) // overridable for testing; nil uses default
 	logger       *log.Logger
 }

--- a/cmd/appie/helpers_test.go
+++ b/cmd/appie/helpers_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"testing"
+
+	appie "github.com/gwillem/appie-go"
+)
+
+func TestFindList(t *testing.T) {
+	lists := []appie.ShoppingList{
+		{ID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", Name: "Boodschappen"},
+		{ID: "11111111-2222-3333-4444-555555555555", Name: "Weekmenu"},
+	}
+
+	t.Run("exact match", func(t *testing.T) {
+		got, err := findList(lists, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Name != "Boodschappen" {
+			t.Fatalf("got %q, want %q", got.Name, "Boodschappen")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := findList(lists, "00000000-0000-0000-0000-000000000000")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("prefix does not match", func(t *testing.T) {
+		_, err := findList(lists, "aaaaaaaa")
+		if err == nil {
+			t.Fatal("expected error for prefix match, got nil")
+		}
+	})
+}

--- a/cmd/appie/list.go
+++ b/cmd/appie/list.go
@@ -1,0 +1,259 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	appie "github.com/gwillem/appie-go"
+)
+
+type shoppingListCommand struct {
+	Show shoppingListShowCommand `command:"show" description:"Show items in a list"`
+	Add  shoppingListAddCommand  `command:"add" description:"Add a product to a list"`
+	Rm   shoppingListRmCommand   `command:"rm" description:"Remove an item from a list"`
+}
+
+func (cmd *shoppingListCommand) Execute(args []string) error {
+	ctx, client, err := orderSetup()
+	if err != nil {
+		return err
+	}
+
+	lists, err := client.GetShoppingLists(ctx, 0)
+	if err != nil {
+		return fmt.Errorf("failed to get shopping lists: %w", err)
+	}
+
+	if len(lists) == 0 {
+		fmt.Println("No shopping lists")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	for _, l := range lists {
+		fmt.Fprintf(w, "  %s\t%d items\n", l.Name, l.ItemCount)
+	}
+	return w.Flush()
+}
+
+// matchList finds a list by case-insensitive prefix match on name.
+// If name is empty and there's exactly one list, returns it as implicit default.
+func matchList(lists []appie.ShoppingList, name string) (*appie.ShoppingList, error) {
+	if name == "" {
+		if len(lists) == 1 {
+			return &lists[0], nil
+		}
+		names := make([]string, len(lists))
+		for i, l := range lists {
+			names[i] = l.Name
+		}
+		return nil, fmt.Errorf("multiple lists, specify one with -l: %s", strings.Join(names, ", "))
+	}
+
+	lower := strings.ToLower(name)
+	var matches []int
+	for i, l := range lists {
+		if strings.HasPrefix(strings.ToLower(l.Name), lower) {
+			matches = append(matches, i)
+		}
+	}
+
+	switch len(matches) {
+	case 1:
+		return &lists[matches[0]], nil
+	case 0:
+		names := make([]string, len(lists))
+		for i, l := range lists {
+			names[i] = l.Name
+		}
+		return nil, fmt.Errorf("no list matching %q, available: %s", name, strings.Join(names, ", "))
+	default:
+		names := make([]string, len(matches))
+		for i, idx := range matches {
+			names[i] = lists[idx].Name
+		}
+		return nil, fmt.Errorf("ambiguous match %q: %s", name, strings.Join(names, ", "))
+	}
+}
+
+// show subcommand
+
+type shoppingListShowCommand struct {
+	Args struct {
+		Name string `positional-arg-name:"name" required:"true"`
+	} `positional-args:"yes"`
+}
+
+func (cmd *shoppingListShowCommand) Execute(args []string) error {
+	ctx, client, err := orderSetup()
+	if err != nil {
+		return err
+	}
+
+	lists, err := client.GetShoppingLists(ctx, 0)
+	if err != nil {
+		return fmt.Errorf("failed to get shopping lists: %w", err)
+	}
+
+	list, err := matchList(lists, cmd.Args.Name)
+	if err != nil {
+		return err
+	}
+
+	items, err := client.GetShoppingListItems(ctx, list.ID)
+	if err != nil {
+		return fmt.Errorf("failed to get list items: %w", err)
+	}
+
+	fmt.Printf("%s (%d items)\n\n", list.Name, len(items))
+
+	if len(items) == 0 {
+		fmt.Println("No items")
+		return nil
+	}
+
+	// Enrich items with product details
+	var productIDs []int
+	for _, item := range items {
+		if item.ProductID > 0 {
+			productIDs = append(productIDs, item.ProductID)
+		}
+	}
+
+	products := make(map[int]*appie.Product)
+	if len(productIDs) > 0 {
+		ps, err := client.GetProductsByIDs(ctx, productIDs)
+		if err != nil {
+			return fmt.Errorf("failed to fetch product details: %w", err)
+		}
+		for i := range ps {
+			products[ps[i].ID] = &ps[i]
+		}
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	for i, item := range items {
+		p := products[item.ProductID]
+		title := item.Name
+		unitSize := ""
+		price := ""
+		if p != nil {
+			title = p.Title
+			unitSize = p.UnitSize
+			if p.Price.Now > 0 {
+				price = fmt.Sprintf("€%.2f", p.Price.Now)
+			}
+		}
+		if title == "" {
+			title = fmt.Sprintf("(product %d)", item.ProductID)
+		}
+		fmt.Fprintf(w, "%2d\t%s\t%s\t%d\t%s\n", i+1, title, unitSize, item.Quantity, price)
+	}
+	return w.Flush()
+}
+
+// add subcommand
+
+type shoppingListAddCommand struct {
+	Args struct {
+		Product string `positional-arg-name:"product" required:"true"`
+	} `positional-args:"yes"`
+	Quantity int    `short:"n" long:"quantity" default:"1" description:"Quantity to add"`
+	List     string `short:"l" long:"list" description:"List name (prefix match)"`
+}
+
+func (cmd *shoppingListAddCommand) Execute(args []string) error {
+	ctx, client, err := orderSetup()
+	if err != nil {
+		return err
+	}
+
+	lists, err := client.GetShoppingLists(ctx, 0)
+	if err != nil {
+		return fmt.Errorf("failed to get shopping lists: %w", err)
+	}
+
+	list, err := matchList(lists, cmd.List)
+	if err != nil {
+		return err
+	}
+
+	product := cmd.Args.Product
+
+	// If numeric, use as product ID directly
+	productID, err := strconv.Atoi(product)
+	if err != nil {
+		// Search for the product
+		products, err := client.SearchProducts(ctx, product, 15)
+		if err != nil {
+			return fmt.Errorf("search failed: %w", err)
+		}
+		if len(products) == 0 {
+			return fmt.Errorf("no products found for %q", product)
+		}
+		if len(products) > 1 {
+			printProducts(products)
+			return fmt.Errorf("multiple matches for %q, specify product ID", product)
+		}
+		productID = products[0].ID
+		fmt.Printf("Found: %s\n", products[0].Title)
+	}
+
+	if err := client.AddToFavoriteList(ctx, list.ID, []int{productID}); err != nil {
+		return err
+	}
+
+	fmt.Printf("Added %dx %d to %s\n", cmd.Quantity, productID, list.Name)
+	return nil
+}
+
+// rm subcommand
+
+type shoppingListRmCommand struct {
+	Args struct {
+		Number int `positional-arg-name:"number" required:"true"`
+	} `positional-args:"yes"`
+	List string `short:"l" long:"list" description:"List name (prefix match)"`
+}
+
+func (cmd *shoppingListRmCommand) Execute(args []string) error {
+	ctx, client, err := orderSetup()
+	if err != nil {
+		return err
+	}
+
+	lists, err := client.GetShoppingLists(ctx, 0)
+	if err != nil {
+		return fmt.Errorf("failed to get shopping lists: %w", err)
+	}
+
+	list, err := matchList(lists, cmd.List)
+	if err != nil {
+		return err
+	}
+
+	items, err := client.GetShoppingListItems(ctx, list.ID)
+	if err != nil {
+		return fmt.Errorf("failed to get list items: %w", err)
+	}
+
+	idx := cmd.Args.Number - 1
+	if idx < 0 || idx >= len(items) {
+		return fmt.Errorf("item %d out of range (list has %d items)", cmd.Args.Number, len(items))
+	}
+
+	item := items[idx]
+	if err := client.RemoveFromShoppingList(ctx, item.ID); err != nil {
+		return err
+	}
+
+	label := item.Name
+	if label == "" {
+		label = fmt.Sprintf("product %d", item.ProductID)
+	}
+	fmt.Printf("Removed #%d (%s) from %s\n", cmd.Args.Number, label, list.Name)
+	return nil
+}

--- a/cmd/appie/list.go
+++ b/cmd/appie/list.go
@@ -16,6 +16,9 @@ type shoppingListCommand struct {
 }
 
 func (cmd *shoppingListCommand) Execute(args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("unknown argument %q, did you mean: appie list show %s", args[0], args[0])
+	}
 	ctx, client, err := orderSetup()
 	if err != nil {
 		return err

--- a/cmd/appie/main.go
+++ b/cmd/appie/main.go
@@ -14,8 +14,8 @@ var globalOpts struct {
 	Verbose bool           `short:"v" long:"verbose" description:"Verbose output"`
 	Login   loginCommand        `command:"login" description:"Login to Albert Heijn"`
 	Search  searchCommand       `command:"search" description:"Search for products"`
-	Receipt receiptCommand      `command:"receipt" description:"List recent receipts"`
-	Order   orderCommand        `command:"order" subcommands-optional:"true" description:"Show active order contents"`
+	Receipt receiptCommand      `command:"receipt" subcommands-optional:"true" description:"List recent receipts"`
+	Order   orderCommand        `command:"order" subcommands-optional:"true" description:"List open orders"`
 	List    shoppingListCommand `command:"list" subcommands-optional:"true" description:"Show shopping lists"`
 }
 

--- a/cmd/appie/main.go
+++ b/cmd/appie/main.go
@@ -12,10 +12,11 @@ import (
 var globalOpts struct {
 	Config  string         `short:"c" long:"config" description:"Path to config file"`
 	Verbose bool           `short:"v" long:"verbose" description:"Verbose output"`
-	Login   loginCommand   `command:"login" description:"Login to Albert Heijn"`
-	Search  searchCommand  `command:"search" description:"Search for products"`
-	Receipt receiptCommand `command:"receipt" description:"List recent receipts"`
-	Order   orderCommand   `command:"order" subcommands-optional:"true" description:"Show active order contents"`
+	Login   loginCommand        `command:"login" description:"Login to Albert Heijn"`
+	Search  searchCommand       `command:"search" description:"Search for products"`
+	Receipt receiptCommand      `command:"receipt" description:"List recent receipts"`
+	Order   orderCommand        `command:"order" subcommands-optional:"true" description:"Show active order contents"`
+	List    shoppingListCommand `command:"list" subcommands-optional:"true" description:"Show shopping lists"`
 }
 
 func clientOpts() []appie.Option {

--- a/cmd/appie/main.go
+++ b/cmd/appie/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -48,7 +47,6 @@ func main() {
 		if flags.WroteHelp(err) {
 			os.Exit(0)
 		}
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/appie/main.go
+++ b/cmd/appie/main.go
@@ -15,6 +15,7 @@ var globalOpts struct {
 	Verbose bool           `short:"v" long:"verbose" description:"Verbose output"`
 	Login   loginCommand   `command:"login" description:"Login to Albert Heijn"`
 	Receipt receiptCommand `command:"receipt" description:"List recent receipts"`
+	Order   orderCommand   `command:"order" subcommands-optional:"true" description:"Show active order contents"`
 }
 
 func clientOpts() []appie.Option {

--- a/cmd/appie/main.go
+++ b/cmd/appie/main.go
@@ -13,6 +13,7 @@ var globalOpts struct {
 	Config  string         `short:"c" long:"config" description:"Path to config file"`
 	Verbose bool           `short:"v" long:"verbose" description:"Verbose output"`
 	Login   loginCommand   `command:"login" description:"Login to Albert Heijn"`
+	Search  searchCommand  `command:"search" description:"Search for products"`
 	Receipt receiptCommand `command:"receipt" description:"List recent receipts"`
 	Order   orderCommand   `command:"order" subcommands-optional:"true" description:"Show active order contents"`
 }

--- a/cmd/appie/order.go
+++ b/cmd/appie/order.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"text/tabwriter"
+
+	appie "github.com/gwillem/appie-go"
+)
+
+type orderCommand struct {
+	List listCommand `command:"list" alias:"ls" description:"List all open orders"`
+	Use  useCommand  `command:"use" description:"Set a different order as active (reopens if submitted)"`
+}
+
+func (cmd *orderCommand) Execute(args []string) error {
+	ctx, client, err := orderSetup()
+	if err != nil {
+		return err
+	}
+
+	fulfillments, err := client.GetFulfillments(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get orders: %w", err)
+	}
+
+	// Try active order first (summary has totals but no per-item prices)
+	var orderID int
+	var summary *appie.Order
+	if s, err := client.GetOrder(ctx); err == nil {
+		summary = s
+		orderID, _ = strconv.Atoi(s.ID)
+	} else if len(fulfillments) > 0 {
+		orderID = fulfillments[0].OrderID
+	} else {
+		fmt.Println("No open orders")
+		return nil
+	}
+
+	// Get detailed line items with pricing
+	order, err := client.GetOrderDetails(ctx, orderID)
+	if err != nil {
+		return fmt.Errorf("failed to get order details: %w", err)
+	}
+
+	// Merge discount info from summary (details endpoint lacks totals)
+	if summary != nil {
+		order.TotalPrice = summary.TotalPrice
+		order.TotalDiscount = summary.TotalDiscount
+	}
+
+	f := findFulfillment(fulfillments, order.ID)
+	return printOrder(order, f)
+}
+
+func findFulfillment(fulfillments []appie.Fulfillment, orderID string) *appie.Fulfillment {
+	for i, f := range fulfillments {
+		if strconv.Itoa(f.OrderID) == orderID {
+			return &fulfillments[i]
+		}
+	}
+	return nil
+}
+
+func printOrder(order *appie.Order, f *appie.Fulfillment) error {
+	fmt.Printf("Order %s  %s\n", order.ID, order.State)
+
+	if f != nil {
+		delivery := f.Delivery.Slot.DateDisplay
+		if f.Delivery.Slot.TimeDisplay != "" {
+			delivery += "  " + f.Delivery.Slot.TimeDisplay
+		}
+		fmt.Printf("Delivery: %s\n", delivery)
+	}
+	fmt.Println()
+
+	if len(order.Items) == 0 {
+		fmt.Println("No items")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	for i, item := range order.Items {
+		// Always show undiscounted price per line
+		unitPrice := item.Product.Price.Now
+		if item.Product.Price.Was > 0 {
+			unitPrice = item.Product.Price.Was
+		}
+		linePrice := float64(item.Quantity) * unitPrice
+
+		fmt.Fprintf(w, "%2d\t%s\t%d\t%6.2f\t%s\n", i+1, item.Product.Title, item.Quantity, linePrice, item.Product.BonusMechanism)
+	}
+
+	// Use API-provided totals (from order summary or fulfillment)
+	total := order.TotalPrice
+	discount := order.TotalDiscount
+	if total == 0 && f != nil && f.TotalPrice > 0 {
+		total = f.TotalPrice
+		subtotal := order.Subtotal()
+		if subtotal > total {
+			discount = subtotal - total
+		}
+	}
+
+	fmt.Fprintf(w, "\t\t\t──────\t\n")
+	if discount > 0 {
+		fmt.Fprintf(w, "\t\t\t-%5.2f\tbonus\n", discount)
+	}
+	fmt.Fprintf(w, "\t\t%d items\t%6.2f\t\n", len(order.Items), total)
+	return w.Flush()
+}
+
+// list subcommand
+
+type listCommand struct{}
+
+func (cmd *listCommand) Execute(args []string) error {
+	ctx, client, err := orderSetup()
+	if err != nil {
+		return err
+	}
+
+	fulfillments, err := client.GetFulfillments(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get orders: %w", err)
+	}
+
+	if len(fulfillments) == 0 {
+		fmt.Println("No open orders")
+		return nil
+	}
+
+	var activeID string
+	if active, err := client.GetOrder(ctx); err == nil {
+		activeID = active.ID
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', tabwriter.AlignRight)
+	fmt.Fprintf(w, "\t%s\t%s\t%s\t%s\t\n", "Order", "Status", "Delivery", "Total")
+	for _, f := range fulfillments {
+		delivery := f.Delivery.Slot.DateDisplay
+		if f.Delivery.Slot.TimeDisplay != "" {
+			delivery += "  " + f.Delivery.Slot.TimeDisplay
+		}
+		marker := " "
+		if strconv.Itoa(f.OrderID) == activeID {
+			marker = "*"
+		}
+		fmt.Fprintf(w, "%s\t%d\t%s\t%s\t%.2f\t\n", marker, f.OrderID, f.Status, delivery, f.TotalPrice)
+	}
+	return w.Flush()
+}
+
+// use subcommand
+
+type useCommand struct {
+	Args struct {
+		OrderID int `positional-arg-name:"order-id" required:"true"`
+	} `positional-args:"yes"`
+}
+
+func (cmd *useCommand) Execute(args []string) error {
+	ctx, client, err := orderSetup()
+	if err != nil {
+		return err
+	}
+
+	orderID := cmd.Args.OrderID
+
+	fulfillments, err := client.GetFulfillments(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get orders: %w", err)
+	}
+
+	var found *appie.Fulfillment
+	for i, f := range fulfillments {
+		if f.OrderID == orderID {
+			found = &fulfillments[i]
+			break
+		}
+	}
+
+	if found == nil {
+		return fmt.Errorf("order %d not found in open orders", orderID)
+	}
+
+	if found.Status == "SUBMITTED" || found.Status == "CONFIRMED" {
+		if err := client.ReopenOrder(ctx, orderID); err != nil {
+			return fmt.Errorf("failed to reopen order: %w", err)
+		}
+		fmt.Printf("Reopened order %d (was %s)\n", orderID, found.Status)
+	}
+
+	fmt.Printf("Active order: %d\n", orderID)
+	return nil
+}
+
+// orderSetup creates an authenticated client and context.
+func orderSetup() (context.Context, *appie.Client, error) {
+	client, err := appie.NewWithConfig(globalOpts.Config, clientOpts()...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to load config: %w", err)
+	}
+
+	if !client.IsAuthenticated() {
+		return nil, nil, fmt.Errorf("not authenticated, run 'appie login' first")
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	_ = cancel // cleaned up when process exits
+	return ctx, client, nil
+}

--- a/cmd/appie/order.go
+++ b/cmd/appie/order.go
@@ -18,6 +18,9 @@ type orderCommand struct {
 }
 
 func (cmd *orderCommand) Execute(args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("unknown argument %q, did you mean: appie order show %s", args[0], args[0])
+	}
 	ctx, client, err := orderSetup()
 	if err != nil {
 		return err

--- a/cmd/appie/order.go
+++ b/cmd/appie/order.go
@@ -1,12 +1,10 @@
 package main
 
 import (
-	"cmp"
 	"context"
 	"fmt"
 	"os"
 	"os/signal"
-	"slices"
 	"strconv"
 	"text/tabwriter"
 
@@ -236,14 +234,7 @@ func (cmd *addCommand) Execute(args []string) error {
 			return fmt.Errorf("no products found for %q", product)
 		}
 		if len(products) > 1 {
-			slices.SortFunc(products, func(a, b appie.Product) int {
-				return cmp.Compare(a.Price.Now, b.Price.Now)
-			})
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-			for _, p := range products {
-				fmt.Fprintf(w, "  %d\t%s\t%s\t€%.2f\n", p.ID, p.Title, p.UnitSize, p.Price.Now)
-			}
-			w.Flush()
+			printProducts(products)
 			return fmt.Errorf("multiple matches for %q, specify product ID", product)
 		}
 		productID = products[0].ID

--- a/cmd/appie/receipt.go
+++ b/cmd/appie/receipt.go
@@ -22,6 +22,9 @@ type receiptCommand struct {
 }
 
 func (cmd *receiptCommand) Execute(args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("unknown argument %q, did you mean: appie receipt show %s", args[0], args[0])
+	}
 	ctx, client, err := orderSetup()
 	if err != nil {
 		return err

--- a/cmd/appie/receipt.go
+++ b/cmd/appie/receipt.go
@@ -12,8 +12,8 @@ import (
 
 // trimMillis strips sub-second precision from a timestamp string (e.g. ".000" in "T14:30:00.000").
 func trimMillis(s string) string {
-	if i := strings.IndexByte(s, '.'); i != -1 {
-		return s[:i]
+	if before, _, ok := strings.Cut(s, "."); ok {
+		return before
 	}
 	return s
 }

--- a/cmd/appie/search.go
+++ b/cmd/appie/search.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"cmp"
+	"fmt"
+	"os"
+	"slices"
+	"text/tabwriter"
+
+	appie "github.com/gwillem/appie-go"
+)
+
+type searchCommand struct {
+	Args struct {
+		Query string `positional-arg-name:"query" required:"true"`
+	} `positional-args:"yes"`
+	Limit int `short:"n" long:"limit" default:"20" description:"Max number of results"`
+}
+
+func (cmd *searchCommand) Execute(args []string) error {
+	ctx, client, err := orderSetup()
+	if err != nil {
+		return err
+	}
+
+	products, err := client.SearchProducts(ctx, cmd.Args.Query, cmd.Limit)
+	if err != nil {
+		return fmt.Errorf("search failed: %w", err)
+	}
+	if len(products) == 0 {
+		return fmt.Errorf("no products found for %q", cmd.Args.Query)
+	}
+
+	printProducts(products)
+	return nil
+}
+
+func printProducts(products []appie.Product) {
+	slices.SortFunc(products, func(a, b appie.Product) int {
+		return cmp.Compare(a.Price.Now, b.Price.Now)
+	})
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	for _, p := range products {
+		fmt.Fprintf(w, "  %d\t%s\t%s\t€%.2f\n", p.ID, p.Title, p.UnitSize, p.Price.Now)
+	}
+	w.Flush()
+}

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -1,0 +1,156 @@
+# CLI Interface
+
+## Global options
+
+```
+appie [options] <command>
+
+  -c, --config PATH    Config file (default: ~/.config/appie/config.json)
+  -v, --verbose        Verbose output
+```
+
+## Commands
+
+### `login`
+
+Open browser for AH OAuth login.
+
+### `receipt [transaction-id]`
+
+List recent receipts, or show details for a specific transaction.
+
+```
+  -n NUM    Number of recent receipts (default: 20)
+```
+
+### `order`
+
+Show contents of the active order. All order subcommands default to the active order.
+
+```
+$ appie order
+Order 1234567  SUBMITTED
+Delivery: dinsdag 25 feb  18:00-20:00
+
+ 1  AH Verse halfvolle melk 2L       1    1.89
+ 2  AH Pindakaas naturel             2    3.58
+ 3  Brinta Origineel                  1    2.49
+                                    ──────
+                            3 items   7.96
+```
+
+#### `order list`
+
+List all open/scheduled orders (fulfillments). Active order marked with `*`.
+
+```
+$ appie order list
+   Order      Status     Delivery                           Total
+*  1234567  SUBMITTED  dinsdag 25 feb  18:00-20:00         87.30
+   1234590  SUBMITTED  vrijdag 28 feb  08:00-10:00         42.15
+```
+
+#### `order add <product-id> [quantity]`
+
+Add a product to the active order. Default quantity is 1.
+
+```
+$ appie order add 371880
+Added 1x Optimel Drinkyoghurt aardbei (€1.59)
+
+$ appie order add 371880 3
+Added 3x Optimel Drinkyoghurt aardbei (€1.59)
+```
+
+#### `order rm <product-id>`
+
+Remove a product from the active order.
+
+```
+$ appie order rm 371880
+Removed Optimel Drinkyoghurt aardbei
+```
+
+#### `order use <order-id>`
+
+Switch the active order to a different fulfillment. Reopens if submitted.
+
+```
+$ appie order use 1234590
+Reopened order 1234590 (was SUBMITTED)
+Active order: 1234590
+```
+
+### `list`
+
+List shopping lists, or show items for a specific list.
+
+```
+  -i, --id ID    Show items for a specific list
+```
+
+```
+$ appie list
+ID                                    Name              Items
+a1b2c3d4-e5f6-7890-abcd-ef1234567890  Boodschappen         12
+f9e8d7c6-b5a4-3210-fedc-ba0987654321  Weekmenu              5
+
+$ appie list -i a1b2c3d4-e5f6-7890-abcd-ef1234567890
+Boodschappen (12 items)
+
+   Product                         Qty  Checked
+   AH Verse halfvolle melk 2L       1
+   AH Pindakaas naturel             2
+   Brinta Origineel                  1   [x]
+   kaas (vrije tekst)               1
+```
+
+### `bonus`
+
+List bonus (promotion) products. Defaults to today.
+
+```
+  -d, --date DATE    Bonus date in YYYY-MM-DD format (default: today)
+  -s, --spotlight    Show only spotlight/featured deals
+```
+
+```
+$ appie bonus
+Bonus week 21 feb - 27 feb
+
+Product                          Was    Now    Discount
+AH Verse pizza               →  4.99   3.49   30% korting
+Alle Hak 370-720ml           →  2.19   1.09   2e halve prijs
+Dove Douchegel 250ml         →  3.29   1.99   1+1 gratis
+...
+(247 products)
+
+$ appie bonus -s
+Bonus week 21 feb - 27 feb (spotlight)
+
+Product                          Was    Now    Discount
+AH Verse pizza               →  4.99   3.49   30% korting
+...
+(12 products)
+
+$ appie bonus -d 2026-02-28
+Bonus week 28 feb - 6 mrt
+...
+```
+
+### `search <query>`
+
+Search products by name. Needed to find product IDs for `order add`.
+
+```
+  -n, --limit NUM    Max results (default: 10)
+```
+
+```
+$ appie search "pindakaas"
+ID       Product                          Price  Bonus
+371880   AH Pindakaas naturel 600g        3.59
+204835   Calvé Pindakaas 650g             4.49   35% korting
+192450   AH Biologisch pindakaas 350g     2.89
+...
+```

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -50,16 +50,32 @@ $ appie order list
    1234590  SUBMITTED  vrijdag 28 feb  08:00-10:00         42.15
 ```
 
-#### `order add <product-id> [quantity]`
+#### `order add <product> [-n quantity]`
 
-Add a product to the active order. Default quantity is 1.
+Add a product to the active order. `<product>` can be a numeric product ID or a search term. Default quantity is 1.
+
+```
+  -n, --quantity NUM    Quantity to add (default: 1)
+```
 
 ```
 $ appie order add 371880
-Added 1x Optimel Drinkyoghurt aardbei (€1.59)
+Added 1x 371880
 
-$ appie order add 371880 3
-Added 3x Optimel Drinkyoghurt aardbei (€1.59)
+$ appie order add 371880 -n 3
+Added 3x 371880
+
+$ appie order add "halfvolle melk"
+Found: AH Halfvolle melk
+Added 1x 12345
+
+$ appie order add "hagelslag puur"
+  32786   AH Hagelslag puur                            250 g    €2.59
+  55732   AH Chocoladepasta puur                       400 g    €2.69
+  465752  AH Hagelslag xl puur                         600 g    €2.99
+  1608    AH Hagelslag puur                            600 g    €2.99
+  ...
+multiple matches for "hagelslag puur", specify product ID
 ```
 
 #### `order rm <product-id>`
@@ -83,26 +99,56 @@ Active order: 1234590
 
 ### `list`
 
-List shopping lists, or show items for a specific list.
-
-```
-  -i, --id ID    Show items for a specific list
-```
+Show shopping lists overview. All list subcommands accept a list name by prefix match.
 
 ```
 $ appie list
-ID                                    Name              Items
-a1b2c3d4-e5f6-7890-abcd-ef1234567890  Boodschappen         12
-f9e8d7c6-b5a4-3210-fedc-ba0987654321  Weekmenu              5
+  Boodschappen  12 items
+  Weekmenu       5 items
+```
 
-$ appie list -i a1b2c3d4-e5f6-7890-abcd-ef1234567890
+#### `list show <name>`
+
+Show items in a list by name (case-insensitive prefix match). Items are numbered for use with `list rm`.
+
+```
+$ appie list show Boodschappen
 Boodschappen (12 items)
 
-   Product                         Qty  Checked
-   AH Verse halfvolle melk 2L       1
-   AH Pindakaas naturel             2
-   Brinta Origineel                  1   [x]
-   kaas (vrije tekst)               1
+ 1  AH Halfvolle melk       1 L    1  €1.89
+ 2  AH Pindakaas naturel    600 g  2  €3.59
+ 3  kaas                           1
+```
+
+#### `list add <product> [-n quantity] [-l name]`
+
+Add a product to a list. `<product>` can be a numeric product ID or a search term. Uses `-l` to select the list by name (optional if only one list exists).
+
+```
+  -n, --quantity NUM    Quantity to add (default: 1)
+  -l, --list NAME       List name (prefix match)
+```
+
+```
+$ appie list add 371880 -l Boodschappen
+Added 1x 371880 to Boodschappen
+
+$ appie list add "pindakaas"
+Found: AH Pindakaas naturel
+Added 1x 371880 to Boodschappen
+```
+
+#### `list rm <number> [-l name]`
+
+Remove an item by its line number from `list show` output.
+
+```
+  -l, --list NAME    List name (prefix match)
+```
+
+```
+$ appie list rm 3 -l Boodschappen
+Removed #3 (kaas) from Boodschappen
 ```
 
 ### `bonus`
@@ -140,17 +186,16 @@ Bonus week 28 feb - 6 mrt
 
 ### `search <query>`
 
-Search products by name. Needed to find product IDs for `order add`.
+Search products by name. Results sorted by price (low to high). Use product IDs with `order add`.
 
 ```
-  -n, --limit NUM    Max results (default: 10)
+  -n, --limit NUM    Max results (default: 20)
 ```
 
 ```
 $ appie search "pindakaas"
-ID       Product                          Price  Bonus
-371880   AH Pindakaas naturel 600g        3.59
-204835   Calvé Pindakaas 650g             4.49   35% korting
-192450   AH Biologisch pindakaas 350g     2.89
-...
+  192450  AH Biologisch pindakaas          350 g  €2.89
+  371880  AH Pindakaas naturel             600 g  €3.59
+  204835  Calvé Pindakaas                  650 g  €4.49
+  ...
 ```

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -9,146 +9,42 @@ appie [options] <command>
   -v, --verbose        Verbose output
 ```
 
+## Command conventions
+
+All resource commands follow a consistent pattern:
+
+```
+appie <resource>                              Overview (list all)
+appie <resource> show <target>                Detail view for one item
+appie <resource> add <target> <item> [flags]  Add item to target
+appie <resource> rm <target> <item>           Remove item from target
+```
+
+- Bare command always shows an overview/list, including IDs for use with subcommands.
+- Mutations always require an explicit target ID as the first positional arg.
+- `<target>` IDs must be specified in full (order IDs are integers, list IDs are UUIDs).
+- `<item>` can be a numeric product ID or a search term (resolved to a single match).
+
 ## Commands
 
 ### `login`
 
 Open browser for AH OAuth login.
 
-### `receipt [transaction-id]`
+### `search <query>`
 
-List recent receipts, or show details for a specific transaction.
-
-```
-  -n NUM    Number of recent receipts (default: 20)
-```
-
-### `order`
-
-Show contents of the active order. All order subcommands default to the active order.
+Search products by name. Results sorted by price (low to high). Use product IDs with `order add` or `list add`.
 
 ```
-$ appie order
-Order 1234567  SUBMITTED
-Delivery: dinsdag 25 feb  18:00-20:00
-
- 1  AH Verse halfvolle melk 2L       1    1.89
- 2  AH Pindakaas naturel             2    3.58
- 3  Brinta Origineel                  1    2.49
-                                    ──────
-                            3 items   7.96
-```
-
-#### `order list`
-
-List all open/scheduled orders (fulfillments). Active order marked with `*`.
-
-```
-$ appie order list
-   Order      Status     Delivery                           Total
-*  1234567  SUBMITTED  dinsdag 25 feb  18:00-20:00         87.30
-   1234590  SUBMITTED  vrijdag 28 feb  08:00-10:00         42.15
-```
-
-#### `order add <product> [-n quantity]`
-
-Add a product to the active order. `<product>` can be a numeric product ID or a search term. Default quantity is 1.
-
-```
-  -n, --quantity NUM    Quantity to add (default: 1)
+  -n, --limit NUM    Max results (default: 20)
 ```
 
 ```
-$ appie order add 371880
-Added 1x 371880
-
-$ appie order add 371880 -n 3
-Added 3x 371880
-
-$ appie order add "halfvolle melk"
-Found: AH Halfvolle melk
-Added 1x 12345
-
-$ appie order add "hagelslag puur"
-  32786   AH Hagelslag puur                            250 g    €2.59
-  55732   AH Chocoladepasta puur                       400 g    €2.69
-  465752  AH Hagelslag xl puur                         600 g    €2.99
-  1608    AH Hagelslag puur                            600 g    €2.99
+$ appie search "pindakaas"
+  192450  AH Biologisch pindakaas          350 g  €2.89
+  371880  AH Pindakaas naturel             600 g  €3.59
+  204835  Calvé Pindakaas                  650 g  €4.49
   ...
-multiple matches for "hagelslag puur", specify product ID
-```
-
-#### `order rm <product-id>`
-
-Remove a product from the active order.
-
-```
-$ appie order rm 371880
-Removed Optimel Drinkyoghurt aardbei
-```
-
-#### `order use <order-id>`
-
-Switch the active order to a different fulfillment. Reopens if submitted.
-
-```
-$ appie order use 1234590
-Reopened order 1234590 (was SUBMITTED)
-Active order: 1234590
-```
-
-### `list`
-
-Show shopping lists overview. All list subcommands accept a list name by prefix match.
-
-```
-$ appie list
-  Boodschappen  12 items
-  Weekmenu       5 items
-```
-
-#### `list show <name>`
-
-Show items in a list by name (case-insensitive prefix match). Items are numbered for use with `list rm`.
-
-```
-$ appie list show Boodschappen
-Boodschappen (12 items)
-
- 1  AH Halfvolle melk       1 L    1  €1.89
- 2  AH Pindakaas naturel    600 g  2  €3.59
- 3  kaas                           1
-```
-
-#### `list add <product> [-n quantity] [-l name]`
-
-Add a product to a list. `<product>` can be a numeric product ID or a search term. Uses `-l` to select the list by name (optional if only one list exists).
-
-```
-  -n, --quantity NUM    Quantity to add (default: 1)
-  -l, --list NAME       List name (prefix match)
-```
-
-```
-$ appie list add 371880 -l Boodschappen
-Added 1x 371880 to Boodschappen
-
-$ appie list add "pindakaas"
-Found: AH Pindakaas naturel
-Added 1x 371880 to Boodschappen
-```
-
-#### `list rm <number> [-l name]`
-
-Remove an item by its line number from `list show` output.
-
-```
-  -l, --list NAME    List name (prefix match)
-```
-
-```
-$ appie list rm 3 -l Boodschappen
-Removed #3 (kaas) from Boodschappen
 ```
 
 ### `bonus`
@@ -170,32 +66,150 @@ Alle Hak 370-720ml           →  2.19   1.09   2e halve prijs
 Dove Douchegel 250ml         →  3.29   1.99   1+1 gratis
 ...
 (247 products)
+```
 
-$ appie bonus -s
-Bonus week 21 feb - 27 feb (spotlight)
+### `receipt`
 
-Product                          Was    Now    Discount
-AH Verse pizza               →  4.99   3.49   30% korting
+List recent receipts.
+
+```
+  -n NUM    Number of recent receipts (default: 20)
+```
+
+```
+$ appie receipt
+2025-02-21T14:30:00  TXN-ABC123   42.50
+2025-02-18T10:15:00  TXN-DEF456   87.30
 ...
-(12 products)
-
-$ appie bonus -d 2026-02-28
-Bonus week 28 feb - 6 mrt
-...
 ```
 
-### `search <query>`
+#### `receipt show <transaction-id>`
 
-Search products by name. Results sorted by price (low to high). Use product IDs with `order add`.
-
-```
-  -n, --limit NUM    Max results (default: 20)
-```
+Show items for a specific receipt.
 
 ```
-$ appie search "pindakaas"
-  192450  AH Biologisch pindakaas          350 g  €2.89
-  371880  AH Pindakaas naturel             600 g  €3.59
-  204835  Calvé Pindakaas                  650 g  €4.49
+$ appie receipt show TXN-ABC123
+Receipt TXN-ABC123
+Date:  2025-02-21T14:30:00
+
+  2x AH Halfvolle melk               3.78
+     AH Pindakaas naturel            3.59
+     Brinta Origineel                 2.49
+
+     Bonus korting                   -1.20
+                                     ------
+     PIN                             42.50
+```
+
+### `order`
+
+List all open/scheduled orders (fulfillments).
+
+```
+$ appie order
+  Order      Status     Delivery                         Total
+  1234567  SUBMITTED  dinsdag 25 feb  18:00-20:00       87.30
+  1234590  SUBMITTED  vrijdag 28 feb  08:00-10:00       42.15
+```
+
+#### `order show <order-id>`
+
+Show contents of a specific order.
+
+```
+$ appie order show 1234567
+Order 1234567  SUBMITTED
+Delivery: dinsdag 25 feb  18:00-20:00
+
+ 1  AH Verse halfvolle melk 2L       1    1.89
+ 2  AH Pindakaas naturel             2    3.58
+ 3  Brinta Origineel                  1    2.49
+                                    ──────
+                            3 items   7.96
+```
+
+#### `order add <order-id> <product> [-n quantity]`
+
+Add a product to an order. `<product>` can be a numeric product ID or a search term. Reopens the order if submitted.
+
+```
+  -n, --quantity NUM    Quantity to add (default: 1)
+```
+
+```
+$ appie order add 1234567 371880
+Added 1x 371880 to order 1234567
+
+$ appie order add 1234567 371880 -n 3
+Added 3x 371880 to order 1234567
+
+$ appie order add 1234567 "halfvolle melk"
+Found: AH Halfvolle melk
+Added 1x 12345 to order 1234567
+
+$ appie order add 1234567 "hagelslag puur"
+  32786   AH Hagelslag puur                            250 g    €2.59
+  55732   AH Chocoladepasta puur                       400 g    €2.69
+  465752  AH Hagelslag xl puur                         600 g    €2.99
+  1608    AH Hagelslag puur                            600 g    €2.99
   ...
+multiple matches for "hagelslag puur", specify product ID
+```
+
+#### `order rm <order-id> <product-id>`
+
+Remove a product from an order. Reopens the order if submitted.
+
+```
+$ appie order rm 1234567 371880
+Removed Optimel Drinkyoghurt aardbei from order 1234567
+```
+
+### `list`
+
+Show shopping lists overview.
+
+```
+$ appie list
+  a1b2c3d4-e5f6-7890-abcd-ef1234567890  Boodschappen  12 items
+  e5f6a7b8-c9d0-1234-5678-abcdef012345  Weekmenu       5 items
+```
+
+#### `list show <list-id>`
+
+Show items in a list. Items are numbered for use with `list rm`.
+
+```
+$ appie list show a1b2c3d4-e5f6-7890-abcd-ef1234567890
+Boodschappen (12 items)
+
+ 1  AH Halfvolle melk       1 L    1  €1.89
+ 2  AH Pindakaas naturel    600 g  2  €3.59
+ 3  kaas                           1
+```
+
+#### `list add <list-id> <product> [-n quantity]`
+
+Add a product to a list. `<product>` can be a numeric product ID or a search term. It will overwrite any existing product quantities.
+
+```
+  -n, --quantity NUM    Quantity to add (default: 1)
+```
+
+```
+$ appie list add a1b2c3d4-e5f6-7890-abcd-ef1234567890 371880
+Added 1x 371880 to Boodschappen
+
+$ appie list add a1b2c3d4-e5f6-7890-abcd-ef1234567890 "pindakaas"
+Found: AH Pindakaas naturel
+Added 1x 371880 to Boodschappen
+```
+
+#### `list rm <list-id> <product>`
+
+Remove an item by its line number from `list show` output. If there are more products, remove all of them.
+
+```
+$ appie list rm a1b2c3d4-e5f6-7890-abcd-ef1234567890 3
+Removed #3 (kaas) from Boodschappen
 ```

--- a/member.go
+++ b/member.go
@@ -53,21 +53,14 @@ type memberResponse struct {
 			First string `json:"first"`
 			Last  string `json:"last"`
 		} `json:"name"`
-		Address struct {
-			Street           string `json:"street"`
-			HouseNumber      int    `json:"houseNumber"`
-			HouseNumberExtra string `json:"houseNumberExtra"`
-			PostalCode       string `json:"postalCode"`
-			City             string `json:"city"`
-			CountryCode      string `json:"countryCode"`
-		} `json:"address"`
-		Cards struct {
+		Address Address `json:"address"`
+		Cards   struct {
 			Bonus    string `json:"bonus"`
 			Gall     string `json:"gall"`
 			Airmiles string `json:"airmiles"`
 		} `json:"cards"`
-		CustomerProfileAudiences   []string `json:"customerProfileAudiences"`
-		CustomerProfileProperties  []struct {
+		CustomerProfileAudiences  []string `json:"customerProfileAudiences"`
+		CustomerProfileProperties []struct {
 			Key   string `json:"key"`
 			Value any    `json:"value"`
 		} `json:"customerProfileProperties"`
@@ -84,24 +77,16 @@ func (c *Client) GetMember(ctx context.Context) (*Member, error) {
 
 	m := resp.Member
 	return &Member{
-		ID:          strconv.Itoa(m.ID),
-		FirstName:   m.Name.First,
-		LastName:    m.Name.Last,
-		Email:       m.EmailAddress,
-		Gender:      m.Gender,
-		DateOfBirth: m.DateOfBirth,
-		PhoneNumber: m.PhoneNumber,
-		Address: Address{
-			Street:           m.Address.Street,
-			HouseNumber:      m.Address.HouseNumber,
-			HouseNumberExtra: m.Address.HouseNumberExtra,
-			PostalCode:       m.Address.PostalCode,
-			City:             m.Address.City,
-			CountryCode:      m.Address.CountryCode,
-		},
+		ID:              strconv.Itoa(m.ID),
+		FirstName:       m.Name.First,
+		LastName:        m.Name.Last,
+		Email:           m.EmailAddress,
+		Gender:          m.Gender,
+		DateOfBirth:     m.DateOfBirth,
+		PhoneNumber:     m.PhoneNumber,
+		Address:         m.Address,
 		BonusCardNumber: m.Cards.Bonus,
 		GallCardNumber:  m.Cards.Gall,
 		Audiences:       m.CustomerProfileAudiences,
 	}, nil
 }
-

--- a/order_test.go
+++ b/order_test.go
@@ -1,0 +1,274 @@
+package appie
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestGetOrderDetails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mobile-services/order/v1/229775812/details-grouped-by-taxonomy" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"orderId":      229775812,
+			"deliveryDate": "2025-12-09",
+			"orderState":   "DELIVERED",
+			"closingTime":  "2025-12-08T22:59:00Z",
+			"deliveryType": "HOME",
+			"deliveryTimePeriod": map[string]any{
+				"startDateTime": "2025-12-09T18:00:00",
+				"endDateTime":   "2025-12-09T20:00:00",
+			},
+			"groupedProductsInTaxonomy": []map[string]any{
+				{
+					"taxonomyName": "Groente, aardappelen",
+					"orderedProducts": []map[string]any{
+						{
+							"amount":   1,
+							"quantity": 2,
+							"product": map[string]any{
+								"webshopId":        164358,
+								"title":            "AH Oranje zoete aardappel",
+								"brand":            "AH",
+								"salesUnitSize":    "1 kg",
+								"priceBeforeBonus": 3.79,
+								"isBonus":          false,
+							},
+						},
+					},
+				},
+				{
+					"taxonomyName": "Zuivel, eieren",
+					"orderedProducts": []map[string]any{
+						{
+							"amount":   1,
+							"quantity": 1,
+							"product": map[string]any{
+								"webshopId":        371880,
+								"title":            "Optimel Drinkyoghurt aardbei",
+								"brand":            "Optimel",
+								"salesUnitSize":    "1 L",
+								"priceBeforeBonus": 1.59,
+								"currentPrice":     1.19,
+								"isBonus":          true,
+								"bonusMechanism":   "25% korting",
+							},
+						},
+					},
+				},
+			},
+			"invoiceId":   "2294567-00199",
+			"cancellable": false,
+		})
+	}))
+	defer srv.Close()
+
+	client := New(WithBaseURL(srv.URL), WithTokens("test", "test"))
+	ctx := context.Background()
+
+	order, err := client.GetOrderDetails(ctx, 229775812)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if order.ID != "229775812" {
+		t.Errorf("expected ID '229775812', got %q", order.ID)
+	}
+	if order.State != "DELIVERED" {
+		t.Errorf("expected state 'DELIVERED', got %q", order.State)
+	}
+	if len(order.Items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(order.Items))
+	}
+
+	item := order.Items[0]
+	if item.ProductID != 164358 {
+		t.Errorf("expected productID 164358, got %d", item.ProductID)
+	}
+	if item.Quantity != 2 {
+		t.Errorf("expected quantity 2, got %d", item.Quantity)
+	}
+	if item.Product == nil {
+		t.Fatal("expected product to be populated")
+	}
+	if item.Product.Title != "AH Oranje zoete aardappel" {
+		t.Errorf("expected title 'AH Oranje zoete aardappel', got %q", item.Product.Title)
+	}
+	if item.Product.Price.Now != 3.79 {
+		t.Errorf("expected price 3.79, got %.2f", item.Product.Price.Now)
+	}
+
+	// Non-bonus item: Price.Now = priceBeforeBonus, Price.Was = 0
+	if item.Product.Price.Was != 0 {
+		t.Errorf("expected Was 0 for non-bonus item, got %.2f", item.Product.Price.Was)
+	}
+
+	item2 := order.Items[1]
+	if item2.ProductID != 371880 {
+		t.Errorf("expected productID 371880, got %d", item2.ProductID)
+	}
+	if !item2.Product.IsBonus {
+		t.Error("expected IsBonus true for second item")
+	}
+
+	// Bonus item: Price.Now = currentPrice, Price.Was = priceBeforeBonus
+	if item2.Product.Price.Now != 1.19 {
+		t.Errorf("expected discounted price 1.19, got %.2f", item2.Product.Price.Now)
+	}
+	if item2.Product.Price.Was != 1.59 {
+		t.Errorf("expected Was 1.59, got %.2f", item2.Product.Price.Was)
+	}
+	if item2.Product.BonusMechanism != "25% korting" {
+		t.Errorf("expected BonusMechanism '25%% korting', got %q", item2.Product.BonusMechanism)
+	}
+}
+
+func TestGetOrderDiscount(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":    12345,
+			"state": "OPEN",
+			"totalPrice": map[string]any{
+				"priceBeforeDiscount": 128.20,
+				"priceAfterDiscount":  92.68,
+				"priceDiscount":       35.52,
+				"priceTotalPayable":   92.68,
+			},
+			"orderedProducts": []map[string]any{
+				{
+					"amount":   1,
+					"quantity": 2,
+					"product": map[string]any{
+						"webshopId": 111,
+						"title":     "Worteltjes",
+						"brand":     "AH",
+						"images":    []any{},
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := New(WithBaseURL(srv.URL), WithTokens("test", "test"))
+	order, err := client.GetOrder(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if order.TotalPrice != 92.68 {
+		t.Errorf("expected TotalPrice 92.68, got %.2f", order.TotalPrice)
+	}
+	if order.TotalDiscount != 35.52 {
+		t.Errorf("expected TotalDiscount 35.52, got %.2f", order.TotalDiscount)
+	}
+}
+
+func TestOrderDetailsTotals(t *testing.T) {
+	data, err := os.ReadFile("testdata/order_details.json")
+	if err != nil {
+		t.Fatalf("read testdata: %v", err)
+	}
+
+	var resp orderDetailsResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	order := resp.toOrder()
+
+	if len(order.Items) != 33 {
+		t.Fatalf("expected 33 items, got %d", len(order.Items))
+	}
+
+	// Verify specific item types are parsed correctly
+	findItem := func(title string) *OrderItem {
+		for i := range order.Items {
+			if order.Items[i].Product.Title == title {
+				return &order.Items[i]
+			}
+		}
+		t.Fatalf("item %q not found", title)
+		return nil
+	}
+
+	// Non-bonus item
+	item := findItem("Boursin Sjalot & bieslook")
+	if item.Product.Price.Now != 3.79 || item.Product.Price.Was != 0 {
+		t.Errorf("non-bonus: Now=%.2f Was=%.2f, want Now=3.79 Was=0", item.Product.Price.Now, item.Product.Price.Was)
+	}
+
+	// Percentage discount (has currentPrice)
+	item = findItem("AH Biologisch Bleekselderij")
+	if item.Product.Price.Now != 1.70 || item.Product.Price.Was != 1.89 {
+		t.Errorf("percentage: Now=%.2f Was=%.2f, want Now=1.70 Was=1.89", item.Product.Price.Now, item.Product.Price.Was)
+	}
+
+	// Group promotion "2e gratis" (no currentPrice)
+	item = findItem("AH Geschrapte worteltjes grootverpakking")
+	if item.Quantity != 2 {
+		t.Errorf("worteltjes qty=%d, want 2", item.Quantity)
+	}
+	if item.Product.Price.Now != 1.79 || item.Product.Price.Was != 0 {
+		t.Errorf("2e gratis: Now=%.2f Was=%.2f, want Now=1.79 Was=0", item.Product.Price.Now, item.Product.Price.Was)
+	}
+	if item.Product.BonusMechanism != "2e gratis" {
+		t.Errorf("mechanism=%q, want %q", item.Product.BonusMechanism, "2e gratis")
+	}
+
+	// Scratch card item (no priceBeforeBonus at all)
+	item = findItem("Alpro Barista haver")
+	if item.Quantity != 3 {
+		t.Errorf("alpro qty=%d, want 3", item.Quantity)
+	}
+	if item.Product.Price.Now != 0 {
+		t.Errorf("scratch card: Now=%.2f, want 0", item.Product.Price.Now)
+	}
+
+	// Subtotal from line items (sum of priceBeforeBonus * qty).
+	// This is less than the API's true pre-discount total because
+	// scratch card items have no price in the details response.
+	subtotal := order.Subtotal()
+	if math.Abs(subtotal-119.97) > 0.01 {
+		t.Errorf("subtotal = %.2f, want 119.97", subtotal)
+	}
+
+	// Simulate CLI merging summary data (from GetOrder)
+	order.TotalPrice = 92.68
+	order.TotalDiscount = 35.52
+
+	// The displayed totals should use API-provided values, not line item math
+	if order.TotalDiscount != 35.52 {
+		t.Errorf("discount = %.2f, want 35.52", order.TotalDiscount)
+	}
+	if order.TotalPrice != 92.68 {
+		t.Errorf("total to pay = %.2f, want 92.68", order.TotalPrice)
+	}
+}
+
+func TestGetOrderDetailsNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{
+			"code":    "NOT_FOUND",
+			"message": "Order not found",
+		})
+	}))
+	defer srv.Close()
+
+	client := New(WithBaseURL(srv.URL), WithTokens("test", "test"))
+	ctx := context.Background()
+
+	_, err := client.GetOrderDetails(ctx, 999999)
+	if err == nil {
+		t.Fatal("expected error for non-existent order")
+	}
+}

--- a/products.go
+++ b/products.go
@@ -209,15 +209,13 @@ func (c *Client) GetProductsByIDs(ctx context.Context, productIDs []int) ([]Prod
 
 	path := "/mobile-services/product/search/v2/products?" + params.Encode()
 
-	var result struct {
-		Products []productResponse `json:"products"`
-	}
+	var result []productResponse
 	if err := c.DoRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
 		return nil, fmt.Errorf("get products by ids failed: %w", err)
 	}
 
-	products := make([]Product, 0, len(result.Products))
-	for _, p := range result.Products {
+	products := make([]Product, 0, len(result))
+	for _, p := range result {
 		products = append(products, p.toProduct())
 	}
 

--- a/products.go
+++ b/products.go
@@ -20,30 +20,24 @@ type searchResponse struct {
 }
 
 type productResponse struct {
-	WebshopID            int             `json:"webshopId"`
-	HqID                 int             `json:"hqId"`
-	Title                string          `json:"title"`
-	Brand                string          `json:"brand"`
-	SalesUnitSize        string          `json:"salesUnitSize"`
-	UnitPriceDescription string          `json:"unitPriceDescription"`
-	Images               []imageResponse `json:"images"`
-	CurrentPrice         float64         `json:"currentPrice"`
-	PriceBeforeBonus     float64         `json:"priceBeforeBonus"`
-	IsBonus              bool            `json:"isBonus"`
-	BonusMechanism       string          `json:"bonusMechanism"`
-	MainCategory         string          `json:"mainCategory"`
-	SubCategory          string          `json:"subCategory"`
-	NutriScore           string          `json:"nutriscore"`
-	AvailableOnline      bool            `json:"availableOnline"`
-	IsPreviouslyBought   bool            `json:"isPreviouslyBought"`
-	IsOrderable          bool            `json:"isOrderable"`
-	PropertyIcons        []string        `json:"propertyIcons"`
-}
-
-type imageResponse struct {
-	Width  int    `json:"width"`
-	Height int    `json:"height"`
-	URL    string `json:"url"`
+	WebshopID            int      `json:"webshopId"`
+	HqID                 int      `json:"hqId"`
+	Title                string   `json:"title"`
+	Brand                string   `json:"brand"`
+	SalesUnitSize        string   `json:"salesUnitSize"`
+	UnitPriceDescription string   `json:"unitPriceDescription"`
+	Images               []Image  `json:"images"`
+	CurrentPrice         float64  `json:"currentPrice"`
+	PriceBeforeBonus     float64  `json:"priceBeforeBonus"`
+	IsBonus              bool     `json:"isBonus"`
+	BonusMechanism       string   `json:"bonusMechanism"`
+	MainCategory         string   `json:"mainCategory"`
+	SubCategory          string   `json:"subCategory"`
+	NutriScore           string   `json:"nutriscore"`
+	AvailableOnline      bool     `json:"availableOnline"`
+	IsPreviouslyBought   bool     `json:"isPreviouslyBought"`
+	IsOrderable          bool     `json:"isOrderable"`
+	PropertyIcons        []string `json:"propertyIcons"`
 }
 
 // GraphQL query for fetching product nutritional info via tradeItem
@@ -78,15 +72,6 @@ type productNutritionResponse struct {
 }
 
 func (p *productResponse) toProduct() Product {
-	var images []Image
-	for _, img := range p.Images {
-		images = append(images, Image{
-			URL:    img.URL,
-			Width:  img.Width,
-			Height: img.Height,
-		})
-	}
-
 	price := p.CurrentPrice
 	if price == 0 {
 		price = p.PriceBeforeBonus
@@ -100,7 +85,7 @@ func (p *productResponse) toProduct() Product {
 		Category:             p.MainCategory,
 		SubCategory:          p.SubCategory,
 		Price:                Price{Now: price, Was: p.PriceBeforeBonus},
-		Images:               images,
+		Images:               p.Images,
 		NutriScore:           p.NutriScore,
 		IsBonus:              p.IsBonus,
 		BonusMechanism:       p.BonusMechanism,

--- a/receipt_test.go
+++ b/receipt_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestGetReceipts(t *testing.T) {
+func TestGetReceiptsIntegration(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -26,7 +26,7 @@ func TestGetReceipts(t *testing.T) {
 	}
 }
 
-func TestGetReceipt(t *testing.T) {
+func TestGetReceiptIntegration(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/shoppinglist_test.go
+++ b/shoppinglist_test.go
@@ -1,0 +1,92 @@
+package appie
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetShoppingListItems(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/graphql" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+
+		resp := graphQLResponse[json.RawMessage]{
+			Data: json.RawMessage(`{
+				"favoriteListV2": [{
+					"id": "LIST-123",
+					"description": "Boodschappen",
+					"totalSize": 3,
+					"items": [
+						{"id": "item-1", "productId": 12345, "quantity": 2},
+						{"id": "item-2", "productId": 67890, "quantity": 1},
+						{"id": "item-3", "productId": 0, "quantity": 1}
+					]
+				}]
+			}`),
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := New(WithBaseURL(srv.URL))
+	items, err := client.GetShoppingListItems(context.Background(), "list-123")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(items) != 3 {
+		t.Fatalf("got %d items, want 3", len(items))
+	}
+
+	if items[0].ID != "item-1" {
+		t.Errorf("got ID %q, want %q", items[0].ID, "item-1")
+	}
+	if items[0].ProductID != 12345 {
+		t.Errorf("got ProductID %d, want 12345", items[0].ProductID)
+	}
+	if items[0].Quantity != 2 {
+		t.Errorf("got Quantity %d, want 2", items[0].Quantity)
+	}
+	if items[2].ProductID != 0 {
+		t.Errorf("got ProductID %d for free-text item, want 0", items[2].ProductID)
+	}
+}
+
+func TestGetShoppingLists(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mobile-services/lists/v3/lists" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+
+		resp := []listResponse{
+			{ID: "abc-123", Description: "Boodschappen", ItemCount: 5},
+			{ID: "def-456", Description: "Weekmenu", ItemCount: 3},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := New(WithBaseURL(srv.URL))
+	lists, err := client.GetShoppingLists(context.Background(), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(lists) != 2 {
+		t.Fatalf("got %d lists, want 2", len(lists))
+	}
+
+	if lists[0].Name != "Boodschappen" {
+		t.Errorf("got Name %q, want %q", lists[0].Name, "Boodschappen")
+	}
+	if lists[0].ItemCount != 5 {
+		t.Errorf("got ItemCount %d, want 5", lists[0].ItemCount)
+	}
+	if lists[1].ID != "def-456" {
+		t.Errorf("got ID %q, want %q", lists[1].ID, "def-456")
+	}
+}

--- a/testdata/order_details.json
+++ b/testdata/order_details.json
@@ -1,0 +1,5868 @@
+{
+  "orderId": 123456789,
+  "deliveryDate": "2026-02-24",
+  "orderState": "CONFIRMED",
+  "closingTime": "2026-02-23T22:59:00Z",
+  "deliveryType": "HOME",
+  "deliveryTimePeriod": {
+    "startDateTime": "2026-02-24T18:00:00",
+    "endDateTime": "2026-02-24T20:00:00",
+    "startTimeUtc": "2026-02-24T17:00:00Z",
+    "endTimeUtc": "2026-02-24T19:00:00Z"
+  },
+  "groupedProductsInTaxonomy": [
+    {
+      "taxonomyName": "Groente, aardappelen",
+      "orderedProducts": [
+        {
+          "amount": 1,
+          "quantity": 1,
+          "allocatedQuantity": 1,
+          "product": {
+            "webshopId": 543987,
+            "hqId": 739513,
+            "title": "Heinz Tomato frito",
+            "brand": "Heinz",
+            "isSample": false,
+            "salesUnitSize": "212 g",
+            "unitPriceDescription": "normale prijs per kg €5.61",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130323037323834?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130323037323834?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130323037323834?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130323037323834?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130323037323834?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 761600,
+            "hqPromotionId": 150580,
+            "bonusSegmentDescription": "Heinz tomato frito 212 gram",
+            "extraDescriptions": [],
+            "discountType": "PO",
+            "promotionType": "PERSONAL",
+            "segmentType": "DIGITAL_SCRATCH_CARD",
+            "activationStatus": "REDEEMABLE",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "1 gratis",
+            "bonusStartDate": "2026-02-02",
+            "bonusEndDate": "2026-03-01",
+            "isBonusPrice": true,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 1,
+            "multipleItemPromotion": true,
+            "labelType": "SCRATCH_SUMMER",
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_SCRATCH_CARD",
+                "defaultDescription": "1 gratis",
+                "count": 1
+              }
+            ],
+            "redemptionCount": 1,
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Pasta, rijst, wereldkeuken",
+            "subCategory": "Gezeefde tomaten, frito, passata",
+            "subCategoryId": 9443,
+            "propertyIcons": [],
+            "properties": {
+              "sp_include_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_exclude_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "da_taste": [
+                "Knoflook",
+                "Ui"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "sp_exclude_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "da_processing_type": [
+                "Geroosterd"
+              ],
+              "sp_include_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "sp_include_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "nutriscore": [
+                "A"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "np_zomerkras": [
+                "Zomerkrasfeest"
+              ],
+              "da_salted_or_not_salted": [
+                "Gezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_exclude_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Houdbaar"
+              ],
+              "da_grape": [],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "sp_exclude_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "da_type_of_processed_food": [
+                "Geroosterd"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "sp_include_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "sp_include_intolerance_geen_gluten": [
+                "Geen gluten"
+              ]
+            },
+            "isPreviouslyBought": true,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003eHeinz tomaten frito is op traditionele wijze bereid, door de knoflook en ui 2,5 uur in olie te laten sudderen en daarna te mengen met zongerijpte tomaten voor een onweerstaanbare rijke smaak.\u003c/p\u003e\u003cp\u003e\u003cul\u003e\u003cli\u003eDe beste kwaliteit zongerijpte tomaten\u003c/li\u003e\u003cli\u003eUitsluitend gemaakt van tomaten geteeld in de open lucht\u003c/li\u003e\u003cli\u003eZonder toegevoegde smaakstoffen of conserveermiddelen en glutenvrij\u003c/li\u003e\u003cli\u003eLekker in een pasta, lasagne, curry of op een pizza\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "Als iets het succes van je gerecht bepaalt, dan is dat een goede basis. Heinz tomato frito is een op traditionele wijze bereide tomatensaus: door de knoflook en ui 2,5 uur in olie te laten sudderen en daarna te mengen met onze heerlijke zongerijpte tomaten ontstaat een onweerstaanbare, rijke smaak. De delicate smaak en de zachte textuur maken dit de perfecte basis voor stoofgerechten, in een pasta, op een pizza of in een rijstgerecht. De variatiemogelijkheden zijn eindeloos!",
+            "isVirtualBundle": false
+          },
+          "position": 9
+        },
+        {
+          "amount": 1,
+          "quantity": 1,
+          "allocatedQuantity": 1,
+          "product": {
+            "webshopId": 186043,
+            "hqId": 582453,
+            "title": "AH Biologisch Bleekselderij",
+            "brand": "AH Biologisch",
+            "isSample": false,
+            "salesUnitSize": "per stuk",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130323033333132?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130323033333132?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130323033333132?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130323033333132?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130323033333132?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 386491,
+            "hqPromotionId": 894383,
+            "bonusSegmentDescription": "PM BIO premium",
+            "extraDescriptions": [],
+            "discountType": "PO",
+            "promotionType": "PERSONAL",
+            "segmentType": "PREMIUM",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "10% KORTING",
+            "bonusStartDate": "2021-09-13",
+            "bonusEndDate": "2099-12-31",
+            "priceBeforeBonus": 1.89,
+            "currentPrice": 1.70,
+            "isBonusPrice": true,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 1383,
+            "multipleItemPromotion": false,
+            "labelType": "PREMIUM",
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_PERCENTAGE",
+                "defaultDescription": "10% korting",
+                "percentage": 10,
+                "precisePercentage": 10
+              }
+            ],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Groente, aardappelen",
+            "subCategory": "Bleekselderij",
+            "subCategoryId": 934,
+            "propertyIcons": [
+              "biologisch"
+            ],
+            "properties": {
+              "sp_include_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Geen toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "sp_include_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "sp_exclude_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "da_taste": [
+                "Prei"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_kenmerk": [
+                "biologisch"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "da_a_type_of_preparation_cookware": [
+                "Koekenpan",
+                "Pan",
+                "Wok",
+                "Braadpan"
+              ],
+              "sp_include_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "sp_include_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "nutriscore": [
+                "A"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "da_salted_or_not_salted": [
+                "Ongezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_include_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "sp_include_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "np_puureerlij": [
+                "puur en eerlijk"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Vers"
+              ],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "np_biologisch": [
+                "biologisch"
+              ],
+              "sp_include_intolerance_geen_gluten": [
+                "Geen gluten"
+              ]
+            },
+            "isPreviouslyBought": true,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003eBleekselderij heeft een zachte en frisse smaak. Je kunt zowel de stengel als het blad goed gebruiken voor het kruiden van een heerlijke soep of bouillon. Tip: ook lekker rauw als gezonde snack.\u003c/p\u003e\u003cp\u003e\u003cul\u003e\u003cli\u003eSmaak: Bleekselderij heeft een zachte frisse smaak.\u003c/li\u003e\u003cli\u003eBewaren: In de koelkast.\u003c/li\u003e\u003cli\u003eGezondheid: 100% Biologisch.\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "",
+            "isVirtualBundle": false,
+            "minBestBeforeDays": 3
+          },
+          "position": 12
+        },
+        {
+          "amount": 4,
+          "quantity": 4,
+          "allocatedQuantity": 4,
+          "product": {
+            "webshopId": 395307,
+            "hqId": 847025,
+            "title": "AH Biologisch Tomatenblokjes",
+            "brand": "AH Biologisch",
+            "isSample": false,
+            "salesUnitSize": "400 g",
+            "unitPriceDescription": "normale prijs per kg €1.48",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_754a344d62736144515071534c6446735f4c78463167?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_754a344d62736144515071534c6446735f4c78463167?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_754a344d62736144515071534c6446735f4c78463167?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_754a344d62736144515071534c6446735f4c78463167?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_754a344d62736144515071534c6446735f4c78463167?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 386491,
+            "hqPromotionId": 894383,
+            "bonusSegmentDescription": "PM BIO premium",
+            "extraDescriptions": [],
+            "discountType": "PO",
+            "promotionType": "PERSONAL",
+            "segmentType": "PREMIUM",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "10% KORTING",
+            "bonusStartDate": "2021-09-13",
+            "bonusEndDate": "2099-12-31",
+            "priceBeforeBonus": 0.59,
+            "currentPrice": 0.53,
+            "isBonusPrice": true,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 1383,
+            "multipleItemPromotion": false,
+            "labelType": "PREMIUM",
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_PERCENTAGE",
+                "defaultDescription": "10% korting",
+                "percentage": 10,
+                "precisePercentage": 10
+              }
+            ],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Pasta, rijst, wereldkeuken",
+            "subCategory": "Tomatenblokjes",
+            "subCategoryId": 1784,
+            "propertyIcons": [
+              "biologisch"
+            ],
+            "properties": {
+              "sp_include_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Geen toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "sp_include_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "da_type_of_addiction": [
+                "Sap"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_kenmerk": [
+                "biologisch"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "sp_include_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "sp_include_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "nutriscore": [
+                "A"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "da_salted_or_not_salted": [
+                "Ongezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_include_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "sp_include_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Houdbaar"
+              ],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "np_biologisch": [
+                "biologisch"
+              ],
+              "sp_include_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "da_cutting_method": [
+                "Blokjes"
+              ],
+              "sp_include_intolerance_geen_gluten": [
+                "Geen gluten"
+              ]
+            },
+            "isPreviouslyBought": false,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003eBlokjes van tomaten uit Itali\u0026#x00EB; die alle tijd hebben gehad om te rijpen. En dat proef je! Deze blokjes zijn vol van smaak en ideaal voor het bereiden van soepen, (pasta)sauzen en pizza.\u003c/p\u003e\u003cp\u003e\u003cul\u003e\u003cli\u003eOok een ideale basis van curry\u003c/li\u003e\u003cli\u003eBiologisch\u003c/li\u003e\u003cli\u003eGemaakt van tomaten uit Itali\u0026#x00EB;\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "\u003cp\u003e Met deze blokjes maak je heel eenvoudig een lasagnemaaltijd. Maak in een ovenschaal afwisselend een laag tomatenblokjes en lasagnebladen met ingredi\u0026#x00EB;nten als aubergine, vis en ui.  \u003c/p\u003e\n  \u003cp\u003eNeem het ervan en geniet van het lekkerste dat de natuur te bieden heeft. Van onze biologische producten kun je met een goed gevoel genieten dankzij de aandacht en inspanning van de boeren en producenten die ze voor ons maken. Natuurlijk worden al onze biologische producten onafhankelijk gecontroleerd en daarom verdienen ze het Europese keurmerk. Biologisch van Albert Heijn: dat smaak naar meer!\u003c/p\u003e",
+            "isVirtualBundle": false
+          },
+          "position": 15
+        },
+        {
+          "amount": 1,
+          "quantity": 1,
+          "allocatedQuantity": 1,
+          "product": {
+            "webshopId": 101130,
+            "hqId": 529604,
+            "title": "AH Biologisch Komkommer",
+            "brand": "AH Biologisch",
+            "isSample": false,
+            "salesUnitSize": "per stuk",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_43545237393530383039?revLabel=2\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_43545237393530383039?revLabel=2\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_43545237393530383039?revLabel=2\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_43545237393530383039?revLabel=2\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_43545237393530383039?revLabel=2\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 386491,
+            "hqPromotionId": 894383,
+            "bonusSegmentDescription": "PM BIO premium",
+            "extraDescriptions": [],
+            "discountType": "PO",
+            "promotionType": "PERSONAL",
+            "segmentType": "PREMIUM",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "10% KORTING",
+            "bonusStartDate": "2021-09-13",
+            "bonusEndDate": "2099-12-31",
+            "priceBeforeBonus": 1.79,
+            "currentPrice": 1.61,
+            "isBonusPrice": true,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 1383,
+            "multipleItemPromotion": false,
+            "labelType": "PREMIUM",
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_PERCENTAGE",
+                "defaultDescription": "10% korting",
+                "percentage": 10,
+                "precisePercentage": 10
+              }
+            ],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Groente, aardappelen",
+            "subCategory": "Komkommer",
+            "subCategoryId": 4979,
+            "propertyIcons": [
+              "biologisch"
+            ],
+            "properties": {
+              "sp_include_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Geen toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "sp_include_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "da_taste": [
+                "Komkommer"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_kenmerk": [
+                "biologisch"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "sp_include_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "sp_include_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "nutriscore": [
+                "A"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "da_salted_or_not_salted": [
+                "Ongezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_include_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "sp_include_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "np_puureerlij": [
+                "puur en eerlijk"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Vers"
+              ],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "np_vorm": [
+                "heel"
+              ],
+              "np_biologisch": [
+                "biologisch"
+              ],
+              "sp_include_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "sp_include_intolerance_geen_gluten": [
+                "Geen gluten"
+              ]
+            },
+            "isPreviouslyBought": true,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003eKomkommer heeft een frisse, knapperige, neutrale smaak. Heerlijk door een salade of als gezonde snack.\u003c/p\u003e\u003cp\u003e\u003cul\u003e\u003cli\u003eSmaak: De komkommer heeft een frisse, knapperige, neutrale smaak.\u003c/li\u003e\u003cli\u003eBewaren: Buiten de koelkast.\u003c/li\u003e\u003cli\u003eGezondheid: 100% Biologisch.\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "",
+            "isVirtualBundle": false,
+            "minBestBeforeDays": 5
+          },
+          "position": 21
+        },
+        {
+          "amount": 2,
+          "quantity": 2,
+          "allocatedQuantity": 2,
+          "product": {
+            "webshopId": 128148,
+            "hqId": 583663,
+            "title": "AH Geschrapte worteltjes grootverpakking",
+            "brand": "AH",
+            "isSample": false,
+            "salesUnitSize": "500 g",
+            "unitPriceDescription": "normale prijs per kg €3.58",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313832353038?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313832353038?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313832353038?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313832353038?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313832353038?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 766809,
+            "hqPromotionId": 154791,
+            "bonusSegmentDescription": "AH Geschrapte worteltjes 500 gram",
+            "extraDescriptions": [
+              "De actieprijs is 1.79"
+            ],
+            "discountType": "AH",
+            "promotionType": "NATIONAL",
+            "segmentType": "AH",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "2e gratis",
+            "bonusStartDate": "2026-02-23",
+            "bonusEndDate": "2026-03-01",
+            "priceBeforeBonus": 1.79,
+            "isBonusPrice": false,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 1,
+            "multipleItemPromotion": true,
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_ONE_FREE",
+                "defaultDescription": "2e gratis",
+                "count": 2
+              }
+            ],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Groente, aardappelen",
+            "subCategory": "Wortel en peen",
+            "subCategoryId": 20903,
+            "propertyIcons": [
+              "goedkoopje",
+              "lokaal"
+            ],
+            "properties": {
+              "sp_include_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Geen toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "sp_include_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "da_taste": [
+                "Wortel"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "np_lokaal": [
+                "nederland"
+              ],
+              "da_a_type_of_preparation_cookware": [
+                "Pan"
+              ],
+              "sp_include_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "sp_include_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "nutriscore": [
+                "A"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "da_salted_or_not_salted": [
+                "Ongezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_include_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "sp_include_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Vers"
+              ],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "np_goedkoopje": [
+                "prijsfavoriet"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "np_vorm": [
+                "gewassen en gesneden"
+              ],
+              "da_accreditation": [
+                "NATUUR_BOER"
+              ],
+              "sp_include_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "np_verbluffen": [
+                "verbluffend goedkoop"
+              ],
+              "sp_include_intolerance_geen_gluten": [
+                "Geen gluten"
+              ]
+            },
+            "isPreviouslyBought": false,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003eNa de oogst worden de worteltjes onmiddellijk\n\t\t\t\tgeselecteerd en zorgvuldig geschrapt. Vervolgens worden de worteltjes gewassen\n\t\t\t\ten meteen verpakt. Zo behouden de worteltjes hun smaak en voedingswaarde.\u003c/p\u003e\u003cp\u003e\u003cul\u003e\u003cli\u003ePrijsfavorieten: topkwaliteit en altijd laaggeprijsd\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "\u003cp\u003e\n   \u003cul\u003e\n   \u003cli\u003e\u003cstrong\u003eSmaak:\u003c/strong\u003e Knapperig, fris en zoet\n    van smaak. \u003c/li\u003e\n   \u003cli\u003e\u003cstrong\u003eBewaren:\u003c/strong\u003e In de koelkast.\n    \u003c/li\u003e\n   \u003cli\u003e\u003cstrong\u003eBereiden:\u003c/strong\u003e Breng een flinke laag\n    water aan de kook. Voeg de worteltjes toe en kook 12-16 minuten. Giet af en\n    voeg naar smaak verse peterselie en/of een scheutje vloeibare margarine toe.\n    Oven (200\u0026#x00B0;C): halveer de worteltjes in de lengte en doe deze in een\n    ovenschaal. Meng met 2 eetlepels (olijf)olie. Voeg naar smaak komijnzaad of\n    kerriepoeder toe. Bak 20-25 minuten in het midden van een voorverwarmde oven.\n    \u003c/li\u003e\n   \u003c/ul\u003e\n  \u003c/p\u003e\u003cp\u003eDit product is een Prijsfavoriet. Dat zijn onze eigen-merkproducten van topkwaliteit en ze zijn altijd voordelig. Je herkent ze aan het blauwe duimpje.\u003c/p\u003e",
+            "isVirtualBundle": false,
+            "minBestBeforeDays": 2
+          },
+          "position": 28
+        },
+        {
+          "amount": 1,
+          "quantity": 1,
+          "allocatedQuantity": 1,
+          "product": {
+            "webshopId": 465601,
+            "hqId": 714549,
+            "title": "AH Snoepgroente tomaat",
+            "brand": "AH",
+            "isSample": false,
+            "salesUnitSize": "1 kg",
+            "unitPriceDescription": "normale prijs per kg €5.99",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303433393635?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303433393635?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303433393635?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303433393635?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303433393635?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 775043,
+            "hqPromotionId": 163024,
+            "bonusSegmentDescription": "AH Snoepgroente tomaat 1 kilo",
+            "extraDescriptions": [
+              "De actieprijs is 4.49"
+            ],
+            "discountType": "AH",
+            "promotionType": "NATIONAL",
+            "segmentType": "AH",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "25% korting",
+            "bonusStartDate": "2026-02-23",
+            "bonusEndDate": "2026-03-01",
+            "priceBeforeBonus": 5.99,
+            "currentPrice": 4.49,
+            "isBonusPrice": true,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 1,
+            "multipleItemPromotion": true,
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_PERCENTAGE",
+                "defaultDescription": "25% korting",
+                "percentage": 25,
+                "precisePercentage": 25
+              }
+            ],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Groente, aardappelen",
+            "subCategory": "Snoepgroente",
+            "subCategoryId": 5159,
+            "propertyIcons": [],
+            "properties": {
+              "sp_include_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Geen toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "sp_include_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "da_taste": [
+                "Tomaat"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "sp_include_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "sp_include_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "nutriscore": [
+                "A"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "da_salted_or_not_salted": [
+                "Ongezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_include_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "sp_include_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Vers"
+              ],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "sp_include_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "sp_include_intolerance_geen_gluten": [
+                "Geen gluten"
+              ]
+            },
+            "isPreviouslyBought": false,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003eSnoeptomaatjes zijn volzoet en sappig van smaak. Deze tomaatjes zijn ideaal als gezonde snack in de lunchtrommel of als extra bite bij de borrel.\u003c/p\u003e\u003cp\u003e\u003cul\u003e\u003cli\u003eSmaak: snoeptomaatjes zijn volzoet en sappig van smaak\u003c/li\u003e\u003cli\u003eBewaren: buiten de koelkast\u003c/li\u003e\u003cli\u003eGezondheid: van nature een bron van vitamine c\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "",
+            "isVirtualBundle": false,
+            "minBestBeforeDays": 2
+          },
+          "position": 29
+        },
+        {
+          "amount": 1,
+          "quantity": 1,
+          "allocatedQuantity": 1,
+          "product": {
+            "webshopId": 440523,
+            "hqId": 704177,
+            "title": "AH Rode linzensoep verspakket",
+            "brand": "AH",
+            "isSample": false,
+            "salesUnitSize": "6 pers | 25 min",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130323031343638?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130323031343638?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130323031343638?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130323031343638?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130323031343638?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 766763,
+            "hqPromotionId": 154745,
+            "bonusSegmentDescription": "AH Verspakket rode linzensoep",
+            "extraDescriptions": [
+              "De actieprijs is 3.99"
+            ],
+            "discountType": "AH",
+            "promotionType": "NATIONAL",
+            "segmentType": "AH",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "1 euro korting",
+            "bonusStartDate": "2026-02-23",
+            "bonusEndDate": "2026-03-01",
+            "priceBeforeBonus": 4.99,
+            "currentPrice": 3.99,
+            "isBonusPrice": true,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 1,
+            "multipleItemPromotion": true,
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_AMOUNT",
+                "defaultDescription": "€1.00 euro korting",
+                "amount": 1.00
+              }
+            ],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Groente, aardappelen",
+            "subCategory": "Soeppakketten",
+            "subCategoryId": 18162,
+            "propertyIcons": [],
+            "properties": {
+              "sp_include_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "sp_include_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "sp_exclude_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "da_taste": [
+                "Linze"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "sp_exclude_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "sp_include_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "nutriscore": [
+                "A"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "da_salted_or_not_salted": [
+                "Gezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_exclude_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Vers"
+              ],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "sp_exclude_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_cutting_method": [
+                "Blokjes"
+              ],
+              "sp_include_intolerance_geen_gluten": [
+                "Geen gluten"
+              ]
+            },
+            "isPreviouslyBought": false,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003eWat handig! Met dit verspakket zet je in een handomdraai een zelfgemaakte rode linzensoep op de eettafel. En het mooie is: het pakket bevat precies de juiste hoeveelheden. No waste, dus!\u003c/p\u003e\u003cp\u003e\u003cul\u003e\u003cli\u003eVoor 4-6 personen\u003c/li\u003e\u003cli\u003eZelf toevoegen: 2 el (olijf)olie, 1 liter water\u003c/li\u003e\u003cli\u003eTip: bestrooi de soep voor het serveren met fijngesneden koriander, platte peterselie, en/of croutons\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "",
+            "isVirtualBundle": false,
+            "minBestBeforeDays": 3
+          },
+          "position": 30
+        }
+      ]
+    },
+    {
+      "taxonomyName": "Fruit, verse sappen",
+      "orderedProducts": [
+        {
+          "amount": 1,
+          "quantity": 1,
+          "allocatedQuantity": 1,
+          "product": {
+            "webshopId": 368480,
+            "hqId": 834184,
+            "title": "AH Biologisch Fairtrade bananen",
+            "brand": "AH Biologisch",
+            "isSample": false,
+            "salesUnitSize": "5 stuks",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_43545236393930313037?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_43545236393930313037?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_43545236393930313037?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_43545236393930313037?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_43545236393930313037?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 386491,
+            "hqPromotionId": 894383,
+            "bonusSegmentDescription": "PM BIO premium",
+            "extraDescriptions": [],
+            "discountType": "PO",
+            "promotionType": "PERSONAL",
+            "segmentType": "PREMIUM",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "10% KORTING",
+            "bonusStartDate": "2021-09-13",
+            "bonusEndDate": "2099-12-31",
+            "priceBeforeBonus": 2.45,
+            "currentPrice": 2.20,
+            "isBonusPrice": true,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 1383,
+            "multipleItemPromotion": false,
+            "labelType": "PREMIUM",
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_PERCENTAGE",
+                "defaultDescription": "10% korting",
+                "percentage": 10,
+                "precisePercentage": 10
+              }
+            ],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Fruit, verse sappen",
+            "subCategory": "Bananen",
+            "subCategoryId": 4941,
+            "propertyIcons": [
+              "vegan",
+              "biologisch"
+            ],
+            "properties": {
+              "sp_include_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Geen toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "da_taste": [
+                "Banaan"
+              ],
+              "sp_include_dieet_vegetarisch": [
+                "Vegetarisch"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_kenmerk": [
+                "biologisch"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "sp_include_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "sp_include_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "nutriscore": [
+                "A"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "sp_include_dieet_veganistisch": [
+                "Veganistisch"
+              ],
+              "da_salted_or_not_salted": [
+                "Ongezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_include_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "sp_include_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Vers"
+              ],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "sp_exclude_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "np_biologisch": [
+                "biologisch"
+              ],
+              "da_accreditation": [
+                "FAIR_TRADE_MARK"
+              ],
+              "sp_include_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "sp_include_intolerance_geen_gluten": [
+                "Geen gluten"
+              ]
+            },
+            "isPreviouslyBought": true,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003eDe banaan is de bekendste tropische fruitsoort. Bananen worden onrijp geoogst en in Nederland verder gerijpt in speciale rijpingskamers. Dit zorgt voor een goede kwaliteit en een heerlijke smaak. Lekker in smoothies, fruitsalade of als gezond tussendoortje.\u003c/p\u003e\u003cp\u003e\u003cul\u003e\u003cli\u003eSmaak: Bananen hebben een zachte en zoete smaak.\u003c/li\u003e\u003cli\u003eBewaren: Buiten de koelkast.\u003c/li\u003e\u003cli\u003eGezondheid: 100% Biologisch.\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "",
+            "isVirtualBundle": false,
+            "minBestBeforeDays": 3
+          },
+          "position": 20
+        }
+      ]
+    },
+    {
+      "taxonomyName": "Maaltijden, salades",
+      "orderedProducts": [
+        {
+          "amount": 1,
+          "quantity": 1,
+          "allocatedQuantity": 1,
+          "product": {
+            "webshopId": 62699,
+            "hqId": 527483,
+            "title": "AH Tortelloni verdi ricotta spinaci",
+            "brand": "AH",
+            "isSample": false,
+            "salesUnitSize": "250 g",
+            "unitPriceDescription": "normale prijs per kg €9.96",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_4938453754746a4653682d414c6a4745344469444b77?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_4938453754746a4653682d414c6a4745344469444b77?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_4938453754746a4653682d414c6a4745344469444b77?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_4938453754746a4653682d414c6a4745344469444b77?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_4938453754746a4653682d414c6a4745344469444b77?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 766841,
+            "hqPromotionId": 154823,
+            "bonusSegmentDescription": "Alle AH Verse pasta's",
+            "extraDescriptions": [
+              "De actieprijzen variëren van 2.49-3.89"
+            ],
+            "discountType": "AH",
+            "promotionType": "NATIONAL",
+            "segmentType": "AH",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "2e gratis",
+            "bonusStartDate": "2026-02-23",
+            "bonusEndDate": "2026-03-01",
+            "priceBeforeBonus": 2.49,
+            "isBonusPrice": false,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 21,
+            "multipleItemPromotion": true,
+            "labelType": "SPOTLIGHT",
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_ONE_FREE",
+                "defaultDescription": "2e gratis",
+                "count": 2
+              }
+            ],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Maaltijden, salades",
+            "subCategory": "Verse pasta",
+            "subCategoryId": 6885,
+            "propertyIcons": [],
+            "properties": {
+              "sp_exclude_intolerance_geen_gluten": [
+                "Geen gluten"
+              ],
+              "sp_exclude_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "sp_exclude_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "sp_exclude_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Toegevoegde suikers"
+              ],
+              "sp_include_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "sp_exclude_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "sp_exclude_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "da_taste": [
+                "Spinazie"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_exclude_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "sp_exclude_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "sp_exclude_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_exclude_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "da_processing_type": [
+                "Gevuld"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "nutriscore": [
+                "C"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "da_salted_or_not_salted": [
+                "Gezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_exclude_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "sp_exclude_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Vers"
+              ],
+              "sp_exclude_dieet_veganistisch": [
+                "Veganistisch"
+              ],
+              "da_type_of_processed_food": [
+                "Gevuld"
+              ],
+              "sp_exclude_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "sp_exclude_dieet_vegetarisch": [
+                "Vegetarisch"
+              ],
+              "da_type_of_egg": [
+                "Vrije uitloopei"
+              ],
+              "np_soort": [
+                "tortellini"
+              ],
+              "da_type_of_grain": [
+                "Durum",
+                "Tarwe"
+              ],
+              "sp_exclude_intolerance_geen_eieren": [
+                "Geen eieren"
+              ]
+            },
+            "isPreviouslyBought": false,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003eVerse eierpasta gevuld met ricottakaas en spinazie.\u003c/p\u003e",
+            "descriptionFull": "\u003cp\u003e\n   \u003cul\u003e\n   \u003cli\u003eAllergie-informatie: bevat tarwe (gluten), lactose, koemelkeiwit, ei. Gemaakt in een bedrijf waar ook noten worden verwerkt. \u003c/li\u003e\n   \u003cli\u003eServeertip: roerbak 1 zakje verse spinazie in 2 eetlepels olijfolie. Voeg 200 g slagroom toe en 3 eetlepels Parmezaanse kaas en meng dit met de pasta. \u003c/li\u003e\n   \u003c/ul\u003e\n  \u003c/p\u003e",
+            "isVirtualBundle": false,
+            "minBestBeforeDays": 10
+          },
+          "position": 26
+        },
+        {
+          "amount": 1,
+          "quantity": 1,
+          "allocatedQuantity": 1,
+          "product": {
+            "webshopId": 103429,
+            "hqId": 555434,
+            "title": "AH Verse ravioli ai funghi",
+            "brand": "AH",
+            "isSample": false,
+            "salesUnitSize": "250 g",
+            "unitPriceDescription": "normale prijs per kg €9.96",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_43545239383936313438?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_43545239383936313438?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_43545239383936313438?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_43545239383936313438?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_43545239383936313438?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 766841,
+            "hqPromotionId": 154823,
+            "bonusSegmentDescription": "Alle AH Verse pasta's",
+            "extraDescriptions": [
+              "De actieprijzen variëren van 2.49-3.89"
+            ],
+            "discountType": "AH",
+            "promotionType": "NATIONAL",
+            "segmentType": "AH",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "2e gratis",
+            "bonusStartDate": "2026-02-23",
+            "bonusEndDate": "2026-03-01",
+            "priceBeforeBonus": 2.49,
+            "isBonusPrice": false,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 21,
+            "multipleItemPromotion": true,
+            "labelType": "SPOTLIGHT",
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_ONE_FREE",
+                "defaultDescription": "2e gratis",
+                "count": 2
+              }
+            ],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Maaltijden, salades",
+            "subCategory": "Verse pasta",
+            "subCategoryId": 6885,
+            "propertyIcons": [
+              "vega"
+            ],
+            "properties": {
+              "sp_exclude_intolerance_geen_gluten": [
+                "Geen gluten"
+              ],
+              "sp_exclude_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "sp_exclude_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "sp_exclude_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Geen toegevoegde suikers"
+              ],
+              "sp_exclude_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "sp_exclude_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "da_taste": [
+                "Paddenstoel"
+              ],
+              "sp_include_dieet_vegetarisch": [
+                "Vegetarisch"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_exclude_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "sp_exclude_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_exclude_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "da_processing_type": [
+                "Gevuld"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "nutriscore": [
+                "C"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "da_salted_or_not_salted": [
+                "Gezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_exclude_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "sp_exclude_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Vers"
+              ],
+              "sp_exclude_dieet_veganistisch": [
+                "Veganistisch"
+              ],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "sp_exclude_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "da_type_of_processed_food": [
+                "Gevuld"
+              ],
+              "sp_exclude_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_type_of_egg": [
+                "Vrije uitloopei"
+              ],
+              "np_soort": [
+                "ravioli"
+              ],
+              "da_type_of_grain": [
+                "Durum",
+                "Tarwe"
+              ],
+              "sp_exclude_intolerance_geen_eieren": [
+                "Geen eieren"
+              ]
+            },
+            "isPreviouslyBought": false,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003eProef het echte italie met deze ravioli gevuld met ricotta en porcini. Serveer bijvoorbeeld met gesmolten boter, tomatensaus, pesto, walnoot- of kaassaus. Bestrooi met geraspte kaas.\u003c/p\u003e\u003cp\u003e\u003cul\u003e\u003cli\u003eVerse eierpasta van 13,5% uitloopeieren\u003c/li\u003e\u003cli\u003eGemaakt in italie\u003c/li\u003e\u003cli\u003eVoor 2 personen\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "",
+            "isVirtualBundle": false,
+            "minBestBeforeDays": 13
+          },
+          "position": 27
+        },
+        {
+          "amount": 1,
+          "quantity": 1,
+          "allocatedQuantity": 1,
+          "product": {
+            "webshopId": 578799,
+            "hqId": 22407,
+            "title": "AH Terra Verse soep linzen",
+            "brand": "AH Terra",
+            "isSample": false,
+            "salesUnitSize": "500 g",
+            "unitPriceDescription": "normale prijs per kg €7.18",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_47767a4e43576b475442472d36536b56466f627a5141?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_47767a4e43576b475442472d36536b56466f627a5141?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_47767a4e43576b475442472d36536b56466f627a5141?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_47767a4e43576b475442472d36536b56466f627a5141?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_47767a4e43576b475442472d36536b56466f627a5141?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 603777,
+            "hqPromotionId": 342,
+            "bonusSegmentDescription": "PM Terra premium",
+            "extraDescriptions": [],
+            "discountType": "PO",
+            "promotionType": "PERSONAL",
+            "segmentType": "PREMIUM",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "10% KORTING",
+            "bonusStartDate": "2023-10-02",
+            "bonusEndDate": "2029-12-31",
+            "priceBeforeBonus": 3.59,
+            "currentPrice": 3.23,
+            "isBonusPrice": true,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 359,
+            "multipleItemPromotion": false,
+            "labelType": "PREMIUM",
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_PERCENTAGE",
+                "defaultDescription": "10% korting",
+                "percentage": 10,
+                "precisePercentage": 10
+              }
+            ],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Maaltijden, salades",
+            "subCategory": "Verse soepen",
+            "subCategoryId": 2279,
+            "propertyIcons": [
+              "vegan"
+            ],
+            "properties": {
+              "sp_include_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "sp_include_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "sp_exclude_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "da_taste": [
+                "Kokos",
+                "Linze",
+                "Pompoen"
+              ],
+              "sp_include_dieet_vegetarisch": [
+                "Vegetarisch"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "da_a_type_of_preparation_cookware": [
+                "Magnetron",
+                "Pan"
+              ],
+              "sp_include_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "sp_include_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "nutriscore": [
+                "B"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "sp_include_dieet_veganistisch": [
+                "Veganistisch"
+              ],
+              "da_salted_or_not_salted": [
+                "Gezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_include_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "sp_exclude_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Vers"
+              ],
+              "da_grape": [],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "sp_include_intolerance_geen_gluten": [
+                "Geen gluten"
+              ]
+            },
+            "isPreviouslyBought": true,
+            "nix18": false,
+            "descriptionHighlights": "",
+            "descriptionFull": "",
+            "isVirtualBundle": false,
+            "minBestBeforeDays": 7
+          },
+          "position": 31
+        },
+        {
+          "amount": 1,
+          "quantity": 1,
+          "allocatedQuantity": 1,
+          "product": {
+            "webshopId": 597813,
+            "hqId": 46408,
+            "title": "AH Verse soep paprika zoete aardappel",
+            "brand": "AH",
+            "isSample": false,
+            "salesUnitSize": "500 g",
+            "unitPriceDescription": "normale prijs per kg €7.18",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_5443356e69355544516e6548777536786b7a36436241?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_5443356e69355544516e6548777536786b7a36436241?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_5443356e69355544516e6548777536786b7a36436241?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_5443356e69355544516e6548777536786b7a36436241?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_5443356e69355544516e6548777536786b7a36436241?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 766876,
+            "hqPromotionId": 154858,
+            "bonusSegmentDescription": "Alle AH Verse soepen 500 gram",
+            "extraDescriptions": [],
+            "discountType": "AH",
+            "promotionType": "NATIONAL",
+            "segmentType": "AH",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "2 voor 6.00",
+            "bonusStartDate": "2026-02-23",
+            "bonusEndDate": "2026-03-01",
+            "priceBeforeBonus": 3.59,
+            "isBonusPrice": false,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 13,
+            "multipleItemPromotion": true,
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_X_FOR_Y",
+                "defaultDescription": "2 voor 6.00",
+                "count": 2,
+                "price": 6.00
+              }
+            ],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Maaltijden, salades",
+            "subCategory": "Verse soepen",
+            "subCategoryId": 2279,
+            "propertyIcons": [
+              "vegan"
+            ],
+            "properties": {
+              "da_a_taste_experience": [
+                "Zoet"
+              ],
+              "sp_include_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "sp_exclude_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "da_taste": [
+                "Kerrie",
+                "Kokos",
+                "Paprika",
+                "Pompoen"
+              ],
+              "sp_include_dieet_vegetarisch": [
+                "Vegetarisch"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "da_a_type_of_preparation_cookware": [
+                "Magnetron",
+                "Pan"
+              ],
+              "sp_include_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "sp_include_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "nutriscore": [
+                "B"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "sp_include_dieet_veganistisch": [
+                "Veganistisch"
+              ],
+              "da_salted_or_not_salted": [
+                "Gezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_include_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "sp_exclude_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Vers"
+              ],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "da_type_of_grain": [
+                "Rijst"
+              ],
+              "sp_include_intolerance_geen_gluten": [
+                "Geen gluten"
+              ]
+            },
+            "isPreviouslyBought": false,
+            "nix18": false,
+            "descriptionHighlights": "",
+            "descriptionFull": "",
+            "isVirtualBundle": false,
+            "minBestBeforeDays": 6
+          },
+          "position": 32
+        }
+      ]
+    },
+    {
+      "taxonomyName": "Vlees",
+      "orderedProducts": [
+        {
+          "amount": 1,
+          "quantity": 1,
+          "allocatedQuantity": 1,
+          "product": {
+            "webshopId": 220401,
+            "hqId": 815436,
+            "title": "AH Biologisch Ontbijtspek",
+            "brand": "AH Biologisch",
+            "isSample": false,
+            "salesUnitSize": "ca. 100 g",
+            "unitPriceDescription": "normale prijs per kg €29.90",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_43545239393435343531?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_43545239393435343531?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_43545239393435343531?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_43545239393435343531?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_43545239393435343531?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 391653,
+            "hqPromotionId": 894384,
+            "bonusSegmentDescription": "PM BIO premium (W)",
+            "extraDescriptions": [],
+            "discountType": "PO",
+            "promotionType": "PERSONAL",
+            "segmentType": "PREMIUM",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "10% KORTING",
+            "bonusStartDate": "2021-09-13",
+            "bonusEndDate": "2099-12-31",
+            "priceBeforeBonus": 2.99,
+            "currentPrice": 2.69,
+            "isBonusPrice": true,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 68,
+            "multipleItemPromotion": true,
+            "labelType": "PREMIUM",
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_PERCENTAGE",
+                "defaultDescription": "10% korting",
+                "percentage": 10,
+                "precisePercentage": 10
+              }
+            ],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Vleeswaren",
+            "subCategory": "Plakken spek en bacon (versafdeling)",
+            "subCategoryId": 4713,
+            "propertyIcons": [
+              "biologisch"
+            ],
+            "properties": {
+              "sp_include_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "sp_include_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_kenmerk": [
+                "biologisch"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "da_animal_species": [
+                "Varken"
+              ],
+              "sp_exclude_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "da_processing_type": [
+                "Gerookt"
+              ],
+              "sp_include_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "sp_include_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "nutriscore": [
+                "E"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "da_salted_or_not_salted": [
+                "Gezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_exclude_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Vers"
+              ],
+              "sp_exclude_dieet_veganistisch": [
+                "Veganistisch"
+              ],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "da_type_of_processed_food": [
+                "Gerookt"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "sp_exclude_dieet_vegetarisch": [
+                "Vegetarisch"
+              ],
+              "np_biologisch": [
+                "biologisch"
+              ],
+              "da_accreditation": [
+                "BETER_LEVEN_3_STER"
+              ],
+              "sp_include_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "sp_include_intolerance_geen_gluten": [
+                "Geen gluten"
+              ]
+            },
+            "isPreviouslyBought": true,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003e\u003cul\u003e\u003cli\u003eSmaak: Zout, rook\u003c/li\u003e\u003cli\u003eVleessoort: Varkensvlees\u003c/li\u003e\u003cli\u003eLekker op een plak roggebrood of om uit te bakken\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "\u003cp\u003e Neem het ervan en geniet van het lekkerste dat de natuur te bieden heeft. Van onze biologische producten kun je met een goed gevoel genieten dankzij de aandacht en inspanning van de boeren en producenten die ze voor ons maken. Natuurlijk worden al onze biologische producten onafhankelijk gecontroleerd en daarom verdienen ze het Europese keurmerk. Biologisch van Albert Heijn: dat smaakt naar meer!  \u003c/p\u003e\n  \u003cp\u003eOntbijtspek is een exclusieve kwaliteit door als enige droge zouten toe te passen en extra lang te rijpen, het spek wordt hierdoor mals en smaakvol. Bovendien spettert het minder bij het uitbakken.\u003c/p\u003e",
+            "isVirtualBundle": false,
+            "minBestBeforeDays": 7
+          },
+          "position": 14
+        }
+      ]
+    },
+    {
+      "taxonomyName": "Vis",
+      "orderedProducts": [
+        {
+          "amount": 1,
+          "quantity": 1,
+          "allocatedQuantity": 1,
+          "product": {
+            "webshopId": 142193,
+            "hqId": 530335,
+            "title": "AH Zalmfilet",
+            "brand": "AH",
+            "isSample": false,
+            "salesUnitSize": "ca. 580 g",
+            "unitPriceDescription": "normale prijs per kg €29.99",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303938303130?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303938303130?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303938303130?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303938303130?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303938303130?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 766849,
+            "hqPromotionId": 154831,
+            "bonusSegmentDescription": "Alle AH Verse zalmfilet zonder huid*",
+            "extraDescriptions": [
+              "De actieprijzen per kilo variëren van 20.42-24.66",
+              "*M.u.v. Biologisch"
+            ],
+            "discountType": "AH",
+            "promotionType": "NATIONAL",
+            "segmentType": "AH",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "25% korting",
+            "bonusStartDate": "2026-02-23",
+            "bonusEndDate": "2026-03-01",
+            "priceBeforeBonus": 17.39,
+            "currentPrice": 13.04,
+            "isBonusPrice": true,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 4,
+            "multipleItemPromotion": false,
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_PERCENTAGE",
+                "defaultDescription": "25% korting",
+                "percentage": 25,
+                "precisePercentage": 25
+              }
+            ],
+            "exceptionRule": "*M.u.v. Biologisch",
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Vis",
+            "subCategory": "Zalm (vers)",
+            "subCategoryId": 5430,
+            "propertyIcons": [],
+            "properties": {
+              "sp_exclude_intolerance_geen_gluten": [
+                "Geen gluten"
+              ],
+              "sp_exclude_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "sp_include_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Geen toegevoegde suikers"
+              ],
+              "sp_include_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "sp_exclude_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_exclude_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "da_animal_species": [
+                "Zalm"
+              ],
+              "sp_exclude_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "da_a_type_of_preparation_cookware": [
+                "Koekenpan",
+                "Oven",
+                "Pan"
+              ],
+              "sp_exclude_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "sp_include_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "nutriscore": [
+                "A"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "da_salted_or_not_salted": [
+                "Ongezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_exclude_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "sp_include_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "da_free_of_sugar": [
+                "Ja"
+              ],
+              "da_store_department": [
+                "Vers"
+              ],
+              "da_grape": [],
+              "sp_exclude_dieet_veganistisch": [
+                "Veganistisch"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "sp_exclude_dieet_vegetarisch": [
+                "Vegetarisch"
+              ],
+              "da_accreditation": [
+                "AQUACULTURE_STEWARDSHIP_COUNCIL"
+              ],
+              "sp_include_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "np_soort": [
+                "zalm"
+              ],
+              "da_regionalism": [
+                "Noors"
+              ],
+              "sp_exclude_intolerance_geen_eieren": [
+                "Geen eieren"
+              ]
+            },
+            "isPreviouslyBought": true,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003eDe zalm wordt gekweekt in Noorwegen en is ASC-gecertificeerd. De keten is gesloten en daardoor transparant, we weten precies wat voor leven de zalm heeft gehad en waar de zalm vandaan komt.\u003c/p\u003e\u003cp\u003e\u003cul\u003e\u003cli\u003eVan nature rijk aan omega-3-vetzuren, eiwitten en vitamine D\u003c/li\u003e\u003cli\u003eVers en onbewerkt\u003c/li\u003e\u003cli\u003eZalmfilet is makkelijk te bereiden, in een pasta, salade of met wat groente\u003c/li\u003e\u003cli\u003eHet Voedingscentrum adviseert om eens per week een portie vis te eten, bij voorkeur vette vis zoals zalm\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "",
+            "isVirtualBundle": false,
+            "minBestBeforeDays": 2
+          },
+          "position": 33
+        },
+        {
+          "amount": 1,
+          "quantity": 1,
+          "allocatedQuantity": 1,
+          "product": {
+            "webshopId": 121444,
+            "hqId": 545208,
+            "title": "AH Haringfilet met uitjes",
+            "brand": "AH",
+            "isSample": false,
+            "salesUnitSize": "2 stuks",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303937393733?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303937393733?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303937393733?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303937393733?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303937393733?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 766803,
+            "hqPromotionId": 154785,
+            "bonusSegmentDescription": "AH Haring met uitjes 2 stuks",
+            "extraDescriptions": [],
+            "discountType": "AH",
+            "promotionType": "NATIONAL",
+            "segmentType": "AH",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "VOOR 1.99",
+            "bonusStartDate": "2026-02-23",
+            "bonusEndDate": "2026-03-01",
+            "priceBeforeBonus": 2.89,
+            "currentPrice": 1.99,
+            "isBonusPrice": true,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 2,
+            "multipleItemPromotion": true,
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_FIXED_PRICE",
+                "defaultDescription": "voor 1.99",
+                "price": 1.99
+              }
+            ],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Vis",
+            "subCategory": "Haring (vers)",
+            "subCategoryId": 2594,
+            "propertyIcons": [],
+            "properties": {
+              "sp_include_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Geen toegevoegde suikers"
+              ],
+              "sp_include_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_kenmerk": [
+                "duurzame vangst"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "da_animal_species": [
+                "Haring"
+              ],
+              "sp_exclude_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "sp_include_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "sp_include_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "nutriscore": [
+                "D"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "da_salted_or_not_salted": [
+                "Gezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_exclude_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "sp_exclude_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "np_puureerlij": [
+                "puur en eerlijk"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Vers"
+              ],
+              "sp_exclude_dieet_veganistisch": [
+                "Veganistisch"
+              ],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "sp_exclude_dieet_vegetarisch": [
+                "Vegetarisch"
+              ],
+              "da_accreditation": [
+                "MARINE_STEWARDSHIP_COUNCIL_LABEL"
+              ],
+              "sp_include_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "np_soort": [
+                "haring"
+              ],
+              "np_duurzaam": [
+                "duurzame vangst"
+              ],
+              "sp_include_intolerance_geen_gluten": [
+                "Geen gluten"
+              ]
+            },
+            "isPreviouslyBought": true,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003eHaringfilet met 20 gram uitjes\u003c/p\u003e",
+            "descriptionFull": "\u003cp\u003e\n   \u003cul\u003e\n   \u003cli\u003eHaring (Clupea harengus)gevangen in het noordoostelijk deel van de Atlantische Oceaan. \u003c/li\u003e\n   \u003c/ul\u003e\n  \u003c/p\u003e",
+            "isVirtualBundle": false,
+            "minBestBeforeDays": 2
+          },
+          "position": 34
+        }
+      ]
+    },
+    {
+      "taxonomyName": "Vegetarisch, vegan en plantaardig",
+      "orderedProducts": [
+        {
+          "amount": 3,
+          "quantity": 3,
+          "allocatedQuantity": 3,
+          "product": {
+            "webshopId": 538253,
+            "hqId": 741659,
+            "title": "Alpro Barista haver",
+            "brand": "Alpro",
+            "isSample": false,
+            "salesUnitSize": "0,5 l",
+            "unitPriceDescription": "normale prijs per liter €3.90",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303630333536?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303630333536?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303630333536?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303630333536?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303630333536?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 761683,
+            "hqPromotionId": 150663,
+            "bonusSegmentDescription": "Alpro barista haver 500 ml",
+            "extraDescriptions": [],
+            "discountType": "PO",
+            "promotionType": "PERSONAL",
+            "segmentType": "DIGITAL_SCRATCH_CARD",
+            "activationStatus": "REDEEMABLE",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "3 gratis",
+            "bonusStartDate": "2026-02-02",
+            "bonusEndDate": "2026-03-01",
+            "isBonusPrice": true,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 1,
+            "multipleItemPromotion": true,
+            "labelType": "SCRATCH_SUMMER",
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_SCRATCH_CARD",
+                "defaultDescription": "3 gratis",
+                "count": 3
+              }
+            ],
+            "redemptionCount": 3,
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Vegetarisch, vegan en plantaardig",
+            "subCategory": "Haverdrink",
+            "subCategoryId": 8610,
+            "propertyIcons": [
+              "vegan"
+            ],
+            "properties": {
+              "sp_exclude_intolerance_geen_gluten": [
+                "Geen gluten"
+              ],
+              "da_a_taste_experience": [
+                "Mild"
+              ],
+              "sp_include_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "da_taste": [
+                "Yoghurt"
+              ],
+              "sp_include_dieet_vegetarisch": [
+                "Vegetarisch"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "sp_exclude_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "sp_include_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "sp_include_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "nutriscore": [
+                "A"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "sp_include_dieet_veganistisch": [
+                "Veganistisch"
+              ],
+              "np_zomerkras": [
+                "Zomerkrasfeest"
+              ],
+              "da_salted_or_not_salted": [
+                "Gezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_include_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Houdbaar"
+              ],
+              "da_grape": [],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "sp_exclude_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "sp_include_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "da_cutting_method": [
+                "Creme"
+              ],
+              "da_type_of_grain": [
+                "Haver"
+              ]
+            },
+            "isPreviouslyBought": false,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003eAlpro barista haver past perfect in koffie van vrijwel elke boon, melange of manier van branden. Geef je lievelingskoffie een ware barista ervaring met de perfecte schuimlaag.\u003c/p\u003e\u003cp\u003e\u003cul\u003e\u003cli\u003ePlantaardig met de zachte, subtiel zoete smaak van in europa geoogste haver\u003c/li\u003e\u003cli\u003eSpeciaal ontwikkeld om op te schuimen, zowel warm als koud\u003c/li\u003e\u003cli\u003eBron van vezels en vitamine B2, B12 en D\u003c/li\u003e\u003cli\u003eVan nature lactosevrij en vegan\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "Eenmaal geproefd dan weet je het, je bent verkocht! Met deze drink kun je eindeloos in je koffie combineren. Schuim de melk op voor een lekkere plantaardige cappuccino, latte macchiato, koffie verkeerd of voeg toe aan je ijskoffie. Gezien onze haverdrank plantaardig en van nature lactosevrij is, past hij perfect in een plant based, zuivelvrij, veganistisch of vegetarisch dieet/ recept. Alpro wil jou en andere mensen inspireren om vaker voor plantaardige voeding te kiezen. Omdat het moeilijk is om gezond te leven en oude gewoontes af te zweren, helpen we mensen die willen veranderen een handje met onze producten.",
+            "isVirtualBundle": false
+          },
+          "position": 11
+        },
+        {
+          "amount": 1,
+          "quantity": 1,
+          "allocatedQuantity": 1,
+          "product": {
+            "webshopId": 414982,
+            "hqId": 857086,
+            "title": "Vegetarische Slager Vegan petit filet americain",
+            "brand": "Vegetarische Slager",
+            "isSample": false,
+            "salesUnitSize": "5 x 24 g",
+            "unitPriceDescription": "normale prijs per kg €21.58",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_43545239353639393237?revLabel=2\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_43545239353639393237?revLabel=2\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_43545239353639393237?revLabel=2\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_43545239353639393237?revLabel=2\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_43545239353639393237?revLabel=2\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 766945,
+            "hqPromotionId": 154927,
+            "bonusSegmentDescription": "Alle De Vegetarische Slager",
+            "extraDescriptions": [
+              "De actieprijzen variëren van 1.99-6.19"
+            ],
+            "discountType": "AH",
+            "promotionType": "NATIONAL",
+            "segmentType": "AH",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "2e gratis",
+            "bonusStartDate": "2026-02-23",
+            "bonusEndDate": "2026-03-01",
+            "priceBeforeBonus": 2.59,
+            "isBonusPrice": false,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 22,
+            "multipleItemPromotion": true,
+            "labelType": "SPOTLIGHT",
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_ONE_FREE",
+                "defaultDescription": "2e gratis",
+                "count": 2
+              }
+            ],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Vegetarisch, vegan en plantaardig",
+            "subCategory": "Plantaardige vleeswaren",
+            "subCategoryId": 19813,
+            "propertyIcons": [
+              "vegan"
+            ],
+            "properties": {
+              "sp_exclude_intolerance_geen_gluten": [
+                "Geen gluten"
+              ],
+              "sp_include_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "sp_include_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "sp_include_dieet_vegetarisch": [
+                "Vegetarisch"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "sp_exclude_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "sp_include_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "nutriscore": [
+                "D"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "sp_include_dieet_veganistisch": [
+                "Veganistisch"
+              ],
+              "da_salted_or_not_salted": [
+                "Gezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_exclude_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Vers"
+              ],
+              "da_grape": [],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "sp_exclude_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "sp_include_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "da_cutting_method": [
+                "Smeerbaar"
+              ],
+              "da_type_of_grain": [
+                "Haver",
+                "Tarwe"
+              ]
+            },
+            "isPreviouslyBought": false,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003eVegetarische petit filet americain.\u003c/p\u003e\u003cp\u003e\u003cul\u003e\u003cli\u003e100% plantaardig\u003c/li\u003e\u003cli\u003e1- persoons porties\u003c/li\u003e\u003cli\u003eZonder kunstmatige E-nummers\u003c/li\u003e\u003cli\u003eRomig en smeuig\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "",
+            "isVirtualBundle": false,
+            "minBestBeforeDays": 13
+          },
+          "position": 22
+        },
+        {
+          "amount": 1,
+          "quantity": 1,
+          "allocatedQuantity": 1,
+          "product": {
+            "webshopId": 563882,
+            "hqId": 1960,
+            "title": "Vegetarische Slager Vegan Zweedsche gehacktballetjes",
+            "brand": "Vegetarische Slager",
+            "isSample": false,
+            "salesUnitSize": "180 g",
+            "unitPriceDescription": "normale prijs per kg €23.06",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313831343232?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313831343232?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313831343232?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313831343232?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313831343232?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 766945,
+            "hqPromotionId": 154927,
+            "bonusSegmentDescription": "Alle De Vegetarische Slager",
+            "extraDescriptions": [
+              "De actieprijzen variëren van 1.99-6.19"
+            ],
+            "discountType": "AH",
+            "promotionType": "NATIONAL",
+            "segmentType": "AH",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "2e gratis",
+            "bonusStartDate": "2026-02-23",
+            "bonusEndDate": "2026-03-01",
+            "priceBeforeBonus": 4.15,
+            "isBonusPrice": false,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 22,
+            "multipleItemPromotion": true,
+            "labelType": "SPOTLIGHT",
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_ONE_FREE",
+                "defaultDescription": "2e gratis",
+                "count": 2
+              }
+            ],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Vegetarisch, vegan en plantaardig",
+            "subCategory": "Vega balletjes",
+            "subCategoryId": 19351,
+            "propertyIcons": [
+              "vegan"
+            ],
+            "properties": {
+              "sp_exclude_intolerance_geen_gluten": [
+                "Geen gluten"
+              ],
+              "sp_include_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_exclude_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "sp_include_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "sp_exclude_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "da_taste": [
+                "Soja"
+              ],
+              "sp_include_dieet_vegetarisch": [
+                "Vegetarisch"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "da_a_sizing": [
+                "Mini"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "da_a_type_of_preparation_cookware": [
+                "Airfryer",
+                "Oven",
+                "Pan"
+              ],
+              "sp_exclude_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "sp_include_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "nutriscore": [
+                "A"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "sp_include_dieet_veganistisch": [
+                "Veganistisch"
+              ],
+              "da_salted_or_not_salted": [
+                "Gezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_exclude_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Vers"
+              ],
+              "da_grape": [],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "sp_exclude_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_cutting_method": [
+                "Bal"
+              ],
+              "da_type_of_grain": [
+                "Gerst",
+                "Haver",
+                "Tarwe"
+              ],
+              "da_regionalism": [
+                "Zweeds"
+              ]
+            },
+            "isPreviouslyBought": false,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003eDe Vegetarische Slager vegan zweedsche gehacktballetjes laat je niet schieten, het zijn heerlijk malse, veganistische balletjes vol van smaack op basis van soja.\u003c/p\u003e\u003cp\u003e\u003cul\u003e\u003cli\u003eDe Vegetarische Slager vegan zweedsche gehacktballetjes laat je niet liggen\u003c/li\u003e\u003cli\u003eVolledig veganistisch, gemaakt van 100% plantaardige ingredienten\u003c/li\u003e\u003cli\u003eDeze vegan gehaktballetjes op basis van soja bevatten vitamine B12 en ijzer\u003c/li\u003e\u003cli\u003eVleesvervanger voor liefhebbers van de vleessmaak, van vegan tot carnivoor\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "De Vegetarische Slager vegan zweedsche gehacktballetjes: zeg je Zweden? dan zeg je zweedse gehaktballetjes of gehacktbolletjes. De Vegetarische Slager vegan zweedsche gehacktballetjes zijn veganistische balletjes op basis van soja. De gehacktballen zijn een bron van vitamine B12 en ijzer. We maken deze zweedse balletjes trouwens niet alleen vegan, maar ook lecker mals, sappig en vol van smaack. De Vegetarische Slager vegan zweedsche gehacktballetjes zijn overheerlijk met aardappelpuree en jus, bij spaghetti of op een broodje. Dat laat je toch niet schieten! Onze producten zijn minstens zo lekker als het originele product, maar dan ook nog eens goed voor de wereld. De tray is bovendien gemaakt van 100% gerecycled pet plastic en de sleeve is gemaakt van 60% gerecycled karton. Bereidingswijze: pan: verhit 1 el olie in een pan en bak de vegan balletjes gedurende 4-6 minuten, totdat ze een geroosterde kleur hebben. Airfryer: leg de vegan balletjes in een voorverwarmde airfryer op 200 graden celsius en bak in 6-7 minuten. Oven: verwarm de oven voor op 180 graden celsius en bak de vegan balletjes in 12 minuten. In een saus: bereid je favoriete saus naar keuze en voeg de vegan balletjes rechtstreeks toe aan de saus wanneer deze bijna klaar is. Laat de vegan balletjes voor 2 -3 minuten sudderen in de saus. Serveer warm en geniet! Over de vegetarische slager: de Vegetarische Slager is in 2010 geboren vanuit de behoefte van een groot vleesliefhebber: 9e generatie boer jaap korteweg. Hij vond vlees zo lecker, dat hij het vegetarisch maakte. Dat resulteerde in een range aan nostalgische slagersfavorieten, gemaakt door vleesliefhebbers, voor vleesliefhebbers. Onze producten hebben de smaak, structuur en beleving van vlees, zonder dat daar dierlijk vlees aan te Pas komt. De ambachtelijke slager van toen, met het vegetarische vleesch van nu. Zo kan iedere vleesliefhebber - van vegan tot carnivoor - blijven genieten, zonder iets te laten schieten. Onze missie? de grootste slager ter wereld worden en het dier uit de voedselketen halen.",
+            "isVirtualBundle": false,
+            "minBestBeforeDays": 8
+          },
+          "position": 23
+        },
+        {
+          "amount": 1,
+          "quantity": 1,
+          "allocatedQuantity": 1,
+          "product": {
+            "webshopId": 570155,
+            "hqId": 9686,
+            "title": "Vegetarische Slager Cordon blij",
+            "brand": "Vegetarische Slager",
+            "isSample": false,
+            "salesUnitSize": "180 g",
+            "unitPriceDescription": "normale prijs per kg €27.72",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313430353636?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313430353636?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313430353636?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313430353636?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313430353636?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 766945,
+            "hqPromotionId": 154927,
+            "bonusSegmentDescription": "Alle De Vegetarische Slager",
+            "extraDescriptions": [
+              "De actieprijzen variëren van 1.99-6.19"
+            ],
+            "discountType": "AH",
+            "promotionType": "NATIONAL",
+            "segmentType": "AH",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "2e gratis",
+            "bonusStartDate": "2026-02-23",
+            "bonusEndDate": "2026-03-01",
+            "priceBeforeBonus": 4.99,
+            "isBonusPrice": false,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 22,
+            "multipleItemPromotion": true,
+            "labelType": "SPOTLIGHT",
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_ONE_FREE",
+                "defaultDescription": "2e gratis",
+                "count": 2
+              }
+            ],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Vegetarisch, vegan en plantaardig",
+            "subCategory": "Vegetarische schnitzel",
+            "subCategoryId": 7154,
+            "propertyIcons": [
+              "vegan"
+            ],
+            "properties": {
+              "sp_exclude_intolerance_geen_gluten": [
+                "Geen gluten"
+              ],
+              "sp_include_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_exclude_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "sp_include_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "sp_exclude_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "da_taste": [
+                "Soja"
+              ],
+              "sp_include_dieet_vegetarisch": [
+                "Vegetarisch"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "da_a_type_of_preparation_cookware": [
+                "Airfryer",
+                "Oven",
+                "Pan"
+              ],
+              "sp_exclude_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "sp_include_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "nutriscore": [
+                "C"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "sp_include_dieet_veganistisch": [
+                "Veganistisch"
+              ],
+              "da_salted_or_not_salted": [
+                "Gezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_exclude_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Vers"
+              ],
+              "da_grape": [],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "sp_exclude_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_type_of_grain": [
+                "Haver",
+                "Tarwe",
+                "Mais"
+              ]
+            },
+            "isPreviouslyBought": false,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003eDe Vegetarische Slager vegan cordon blij is een plantaardige cordon blue op basis van soja, rijk aan eiwitten.\u003c/p\u003e\u003cp\u003e\u003cul\u003e\u003cli\u003eDe Vegetarische Slager vegan cordon blij laat je hart smelten van genot\u003c/li\u003e\u003cli\u003eEen plantaardige cordon bleu op basis van soja met een krokante korst\u003c/li\u003e\u003cli\u003eEen volledig plantaardige schnitzel met vegan kaas en ham\u003c/li\u003e\u003cli\u003eVleesvervanger voor liefhebbers van de vleessmaak, van carnivoor tot vegan\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "Over de Vegetarische Slager vegan cordon blij: de Vegetarische Slager vegan cordon blij is alles wat je verwacht van de welbekende gelaagde sensatie die menig hart doet smelten. Met een knapperige buitenkant en een romige kern van vegan ham en plantaardige kaas is dit een ware familiefavoriet. Deze plantaardige cordon bleu op basis van soja, verrijkt met vitamine B12 en ijzer, is een bron van eiwitten. De gemakkelijk te bereiden vegan schnitzel met krokante korst, lecker smeuige plantaardige kaas en vegan ham, is 100% plantaardig. Bak 'm goudbruin en krokant in de pan, oven of airfryer en serveer met een lach. Bereidingswijze: pan: verhit 2 eetlepels olie in een pan, bak de vegan cordon blij in 8-10 minuten aan beide kanten goudbruin. Airfryer: leg de vegan cordon blij in een voorverwarmde airfryer op 180 graden celsius en bak gedurende 8 minuten goudbruin. Oven: verwarm de oven voor op 200 graden celsius, leg de vegan cordon blij op een ovenrooster en bak in 10-15 minuten goudbruin. Serveer warm en eet smakelijck! Over de vegetarische slager: de Vegetarische Slager is in 2010 geboren vanuit de behoefte van een groot vleesliefhebber: 9e generatie boer jaap korteweg. Hij vond vlees zo lecker, dat hij het vegetarisch maakte. Dat resulteerde in een range aan nostalgische slagersfavorieten, gemaakt door vleesliefhebbers, voor vleesliefhebbers. Onze producten hebben de smaak, structuur en beleving van vlees, zonder dat daar dierlijk vlees aan te Pas komt. De ambachtelijke slager van toen, met het vegetarische vleesch van nu. Zo kan iedere vleesliefhebber - van vegan tot carnivoor - blijven genieten, zonder iets te laten schieten. Onze missie? de grootste slager ter wereld worden en het dier uit de voedselketen halen.",
+            "isVirtualBundle": false,
+            "minBestBeforeDays": 11
+          },
+          "position": 24
+        },
+        {
+          "amount": 1,
+          "quantity": 1,
+          "allocatedQuantity": 1,
+          "product": {
+            "webshopId": 548743,
+            "hqId": 657615,
+            "title": "Vegetarische Slager Vegan kip krockant",
+            "brand": "Vegetarische Slager",
+            "isSample": false,
+            "salesUnitSize": "200 g",
+            "unitPriceDescription": "normale prijs per kg €24.95",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313533323831?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313533323831?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313533323831?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313533323831?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313533323831?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 766945,
+            "hqPromotionId": 154927,
+            "bonusSegmentDescription": "Alle De Vegetarische Slager",
+            "extraDescriptions": [
+              "De actieprijzen variëren van 1.99-6.19"
+            ],
+            "discountType": "AH",
+            "promotionType": "NATIONAL",
+            "segmentType": "AH",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "2e gratis",
+            "bonusStartDate": "2026-02-23",
+            "bonusEndDate": "2026-03-01",
+            "priceBeforeBonus": 4.99,
+            "isBonusPrice": false,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 22,
+            "multipleItemPromotion": true,
+            "labelType": "SPOTLIGHT",
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_ONE_FREE",
+                "defaultDescription": "2e gratis",
+                "count": 2
+              }
+            ],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Vegetarisch, vegan en plantaardig",
+            "subCategory": "Vegetarische schnitzel",
+            "subCategoryId": 7154,
+            "propertyIcons": [
+              "vegan"
+            ],
+            "properties": {
+              "sp_exclude_intolerance_geen_gluten": [
+                "Geen gluten"
+              ],
+              "sp_include_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_exclude_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "sp_include_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "sp_exclude_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "da_taste": [
+                "Cookie dough",
+                "Peper",
+                "Soja"
+              ],
+              "sp_include_dieet_vegetarisch": [
+                "Vegetarisch"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "da_a_type_of_preparation_cookware": [
+                "Airfryer",
+                "Friteuse",
+                "Oven"
+              ],
+              "sp_exclude_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "da_processing_type": [
+                "Gebakken"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "sp_include_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "nutriscore": [
+                "B"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "sp_include_dieet_veganistisch": [
+                "Veganistisch"
+              ],
+              "da_salted_or_not_salted": [
+                "Gezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_exclude_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Vers"
+              ],
+              "da_grape": [],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "da_type_of_processed_food": [
+                "Gebakken"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "sp_exclude_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_type_of_grain": [
+                "Haver",
+                "Tarwe"
+              ]
+            },
+            "isPreviouslyBought": false,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003eDe Vegetarische Slager vegan kip krockant is een knapperige allemansvriend die de leckerste landing maakt in een salade, op een broodje of bij een traditionele maaltijd met aardappelen en groente.\u003c/p\u003e\u003cp\u003e\u003cul\u003e\u003cli\u003eDe Vegetarische Slager vegan kip krockant is een knapperige allemansvriend\u003c/li\u003e\u003cli\u003eVolledig veganistisch, gemaakt van 100% plantaardige ingredienten\u003c/li\u003e\u003cli\u003eEen vegan filet op basis van soja en bevat vitamine B12 en ijzer\u003c/li\u003e\u003cli\u003eVleesvervanger voor liefhebbers van de vleessmaak, van carnivoor tot vegan\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "Waarom de Vegetarische Slager vegan kip krockant? fried chicken? we freed the chicken! De Vegetarische Slager vegan kip krockant is een malse filet gehuld in een krokant jasje, gekruid met zwarte peper. Deze krokante, veganistische filet is gemaakt op basis van soja met ijzer en vitamine B12. Een knapperige allemansvriend die de leckerste landing maakt in een salade, op een broodje of bij een traditionele maaltijd met aardappelen en groente. Ook perfeckt als snack, bij een borrel. Bereidingswijze: de kip krockant is heel makkelijk te bereiden. Kwestie van even bakken in de pan, oven, airfryer of frituur tot hij goudbruin is. Kippenvel, zo lecker! Over de vegetarische slager: de Vegetarische Slager is in 2010 geboren vanuit de behoefte van een groot vleesliefhebber. We willen meegaan met onze tijd. De ambachtelijke slager van toen maakt nu Ambachtelijk en volledig vegetarisch vleesch. Zo kunnen zowel carnivoren als veganisten genieten van een vleessmaak, zonder nog dieren te hoeven eten. Onze producten zijn minstens zo lekker als het originele product, maar dan ook nog eens goed voor de wereld. De tray is gemaakt met 100% gerecycled pet plastic en de sleeve is gemaakt van 60% gerecycled karton. Onze missie? de grootste slager ter wereld worden zonder dat daar een dier aan te Pas hoeft te komen!",
+            "isVirtualBundle": false,
+            "minBestBeforeDays": 11
+          },
+          "position": 25
+        }
+      ]
+    },
+    {
+      "taxonomyName": "Kaas",
+      "orderedProducts": [
+        {
+          "amount": 1,
+          "quantity": 1,
+          "allocatedQuantity": 1,
+          "product": {
+            "webshopId": 33648,
+            "hqId": 74198,
+            "title": "Parrano Geraspte kaas originale",
+            "brand": "Parrano",
+            "isSample": false,
+            "salesUnitSize": "100 g",
+            "unitPriceDescription": "normale prijs per kg €26.90",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_6a504269423845325445364f6e4250454d435a6b5577?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_6a504269423845325445364f6e4250454d435a6b5577?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_6a504269423845325445364f6e4250454d435a6b5577?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_6a504269423845325445364f6e4250454d435a6b5577?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_6a504269423845325445364f6e4250454d435a6b5577?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 766813,
+            "hqPromotionId": 154795,
+            "bonusSegmentDescription": "Alle Parrano*",
+            "extraDescriptions": [
+              "De actieprijzen variëren van 1.95-2.79",
+              "*M.u.v. strooibus"
+            ],
+            "discountType": "AH",
+            "promotionType": "NATIONAL",
+            "segmentType": "AH",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "2e gratis",
+            "bonusStartDate": "2026-02-23",
+            "bonusEndDate": "2026-03-01",
+            "priceBeforeBonus": 2.69,
+            "isBonusPrice": false,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 6,
+            "multipleItemPromotion": true,
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_ONE_FREE",
+                "defaultDescription": "2e gratis",
+                "count": 2
+              }
+            ],
+            "exceptionRule": "*M.u.v. strooibus",
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Kaas",
+            "subCategory": "Geraspte kaas",
+            "subCategoryId": 4238,
+            "propertyIcons": [
+              "vega"
+            ],
+            "properties": {
+              "sp_exclude_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Geen toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "sp_include_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "da_taste": [
+                "Kaas"
+              ],
+              "sp_include_dieet_vegetarisch": [
+                "Vegetarisch"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "da_maturity": [
+                "nvt"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "da_animal_species": [
+                "Rund"
+              ],
+              "np_verpakking": [
+                "voorverpakt"
+              ],
+              "sp_exclude_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_exclude_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "sp_include_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "nutriscore": [
+                "D"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "da_salted_or_not_salted": [
+                "Gezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "da_fat_content": [
+                "45+"
+              ],
+              "sp_exclude_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "da_free_of_sugar": [
+                "Ja"
+              ],
+              "da_store_department": [
+                "Vers"
+              ],
+              "da_grape": [],
+              "sp_exclude_dieet_veganistisch": [
+                "Veganistisch"
+              ],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "sp_include_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "np_soort": [
+                "geraspt, gemalen"
+              ],
+              "sp_include_intolerance_geen_gluten": [
+                "Geen gluten"
+              ]
+            },
+            "isPreviouslyBought": false,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003eParrano rasp originale is een smaakvolle 45+ kaasrasp met een licht zoete, nootachtige en pittige smaak. Dankzij de receptuur smelt de kaas perfect en maakt het elk gerecht onweerstaanbaar lekker.\u003c/p\u003e\u003cp\u003e\u003cul\u003e\u003cli\u003eOriginale kaasrasp 45+, geraspt en gedroogd\u003c/li\u003e\u003cli\u003eLicht zoet, nootachtig en pittig van smaak\u003c/li\u003e\u003cli\u003eGemaakt van gepasteuriseerde melk en vegetarisch\u003c/li\u003e\u003cli\u003ePerfect voor pasta, lasagne, risotto en salade\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "Parrano rasp originale - meer smaak, meer karakter. Maakt elk gerecht echt af.",
+            "isVirtualBundle": false,
+            "minBestBeforeDays": 12
+          },
+          "position": 35
+        },
+        {
+          "amount": 1,
+          "quantity": 1,
+          "allocatedQuantity": 1,
+          "product": {
+            "webshopId": 202113,
+            "hqId": 796275,
+            "title": "Parrano Geraspte kaas snippers originale",
+            "brand": "Parrano",
+            "isSample": false,
+            "salesUnitSize": "80 g",
+            "unitPriceDescription": "normale prijs per kg €32.38",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303431353136?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303431353136?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303431353136?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303431353136?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303431353136?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 766813,
+            "hqPromotionId": 154795,
+            "bonusSegmentDescription": "Alle Parrano*",
+            "extraDescriptions": [
+              "De actieprijzen variëren van 1.95-2.79",
+              "*M.u.v. strooibus"
+            ],
+            "discountType": "AH",
+            "promotionType": "NATIONAL",
+            "segmentType": "AH",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "2e gratis",
+            "bonusStartDate": "2026-02-23",
+            "bonusEndDate": "2026-03-01",
+            "priceBeforeBonus": 2.59,
+            "isBonusPrice": false,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 6,
+            "multipleItemPromotion": true,
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_ONE_FREE",
+                "defaultDescription": "2e gratis",
+                "count": 2
+              }
+            ],
+            "exceptionRule": "*M.u.v. strooibus",
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Kaas",
+            "subCategory": "Geraspte kaas",
+            "subCategoryId": 4238,
+            "propertyIcons": [
+              "vega"
+            ],
+            "properties": {
+              "sp_exclude_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Geen toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "sp_include_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "da_taste": [
+                "Kaas"
+              ],
+              "sp_include_dieet_vegetarisch": [
+                "Vegetarisch"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "da_maturity": [
+                "nvt"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "da_animal_species": [
+                "Rund"
+              ],
+              "np_verpakking": [
+                "voorverpakt"
+              ],
+              "sp_exclude_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_exclude_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "sp_include_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "nutriscore": [
+                "D"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "da_salted_or_not_salted": [
+                "Gezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "da_fat_content": [
+                "40+"
+              ],
+              "sp_exclude_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "da_free_of_sugar": [
+                "Ja"
+              ],
+              "da_store_department": [
+                "Vers"
+              ],
+              "da_grape": [],
+              "sp_exclude_dieet_veganistisch": [
+                "Veganistisch"
+              ],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "np_vorm": [
+                "gemalen"
+              ],
+              "sp_include_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "da_cutting_method": [
+                "Snipper"
+              ],
+              "sp_include_intolerance_geen_gluten": [
+                "Geen gluten"
+              ]
+            },
+            "isPreviouslyBought": false,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003eParrano snippers kaas originale 45+ hebben een licht zoete, nootachtige en pittige smaak dankzij de unieke receptuur. De snippers maken elke pasta, risotto, lasagne of salade onweerstaanbaar lekker.\u003c/p\u003e\u003cp\u003e\u003cul\u003e\u003cli\u003eOriginale kaassnippers 40+\u003c/li\u003e\u003cli\u003eLicht zoet, nootachtig en pittig van smaak\u003c/li\u003e\u003cli\u003eGemaakt van gepasteuriseerde melk en vegetarisch\u003c/li\u003e\u003cli\u003ePerfect voor pasta, lasagne, risotto en salade\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "Parrano snippers originale - meer smaak, meer karakter. Maak elk gerecht echt af.",
+            "isVirtualBundle": false
+          },
+          "position": 36
+        },
+        {
+          "amount": 1,
+          "quantity": 1,
+          "allocatedQuantity": 1,
+          "product": {
+            "webshopId": 213546,
+            "hqId": 804520,
+            "title": "Boursin Sjalot \u0026 bieslook",
+            "brand": "Boursin",
+            "isSample": false,
+            "salesUnitSize": "150 g",
+            "unitPriceDescription": "prijs per kg €25.27",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_4d7a614765585f575242366952486f49486e447a4d51?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_4d7a614765585f575242366952486f49486e447a4d51?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_4d7a614765585f575242366952486f49486e447a4d51?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_4d7a614765585f575242366952486f49486e447a4d51?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_4d7a614765585f575242366952486f49486e447a4d51?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "extraDescriptions": [],
+            "isInfiniteBonus": false,
+            "priceBeforeBonus": 3.79,
+            "isStapelBonus": false,
+            "isBonus": false,
+            "discountLabels": [],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Kaas",
+            "subCategory": "Roomkaas",
+            "subCategoryId": 4687,
+            "propertyIcons": [
+              "vega"
+            ],
+            "properties": {
+              "sp_exclude_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "sp_exclude_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Geen toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "sp_include_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "da_taste": [
+                "Bieslook",
+                "Sjalot",
+                "Roomkaas"
+              ],
+              "sp_include_dieet_vegetarisch": [
+                "Vegetarisch"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_exclude_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "da_maturity": [
+                "nvt"
+              ],
+              "np_verpakking": [
+                "voorverpakt"
+              ],
+              "sp_exclude_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_exclude_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "sp_include_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "nutriscore": [
+                "D"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "da_salted_or_not_salted": [
+                "Gezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_exclude_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Vers"
+              ],
+              "da_grape": [],
+              "sp_exclude_dieet_veganistisch": [
+                "Veganistisch"
+              ],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "np_soort": [
+                "overig"
+              ],
+              "sp_include_intolerance_geen_gluten": [
+                "Geen gluten"
+              ]
+            },
+            "isPreviouslyBought": false,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003eDeze roomkaas combineert de romige textuur van Boursin met de frisse smaken van sjalot en bieslook. Voor als je geen knoflook wil, maar wel smaak wil toevoegen. Perfect voor op de borrelplank.\u003c/p\u003e\u003cp\u003e\u003cul\u003e\u003cli\u003eHeerlijk romig, vol van smaak en met een kruimelige textuur\u003c/li\u003e\u003cli\u003ePerfect bij de borrel op stokbrood en crackers\u003c/li\u003e\u003cli\u003eHeerlijk in hapjes of gerechten zoals pasta of wraps\u003c/li\u003e\u003cli\u003eEen gemakkelijke smaakmaker gemaakt van kwalitatieve ingredienten\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "Boursin is de perfecte smaakmaker om iets lekkers te serveren dankzij zijn veelzijdigheid, heerlijk volle smaak en romige textuur. Het zijn de momenten samen met vrienden en familie die smaak geven aan het leven. Dan wil je niet uren in de keuken staan, maar vooral genieten van je gezelschap. Perfect voor elke gelegenheid, of het nu gaat om een feestelijke borrel, een gezellig etentje of een uitgebreide lunch. Boursin is gemaakt van kwalitatieve ingredienten en biedt zowel klassieke als plantaardige varianten, zodat iedereen kan genieten van deze heerlijke roomkaas. Boursin inspireert, jij creeert",
+            "isVirtualBundle": false,
+            "minBestBeforeDays": 7
+          },
+          "position": 37
+        }
+      ]
+    },
+    {
+      "taxonomyName": "Zuivel, eieren",
+      "orderedProducts": [
+        {
+          "amount": 3,
+          "quantity": 3,
+          "allocatedQuantity": 3,
+          "product": {
+            "webshopId": 61009,
+            "hqId": 106374,
+            "title": "AH Biologisch Volle melk",
+            "brand": "AH Biologisch",
+            "isSample": false,
+            "salesUnitSize": "1 l",
+            "unitPriceDescription": "normale prijs per liter €1.45",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313833303935?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313833303935?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313833303935?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313833303935?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313833303935?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 386491,
+            "hqPromotionId": 894383,
+            "bonusSegmentDescription": "PM BIO premium",
+            "extraDescriptions": [],
+            "discountType": "PO",
+            "promotionType": "PERSONAL",
+            "segmentType": "PREMIUM",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "10% KORTING",
+            "bonusStartDate": "2021-09-13",
+            "bonusEndDate": "2099-12-31",
+            "priceBeforeBonus": 1.45,
+            "currentPrice": 1.30,
+            "isBonusPrice": true,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 1383,
+            "multipleItemPromotion": false,
+            "labelType": "PREMIUM",
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_PERCENTAGE",
+                "defaultDescription": "10% korting",
+                "percentage": 10,
+                "precisePercentage": 10
+              }
+            ],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Zuivel, eieren",
+            "subCategory": "Volle melk",
+            "subCategoryId": 2392,
+            "propertyIcons": [
+              "vega",
+              "lokaal",
+              "biologisch"
+            ],
+            "properties": {
+              "sp_exclude_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Geen toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "sp_include_dieet_vegetarisch": [
+                "Vegetarisch"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_kenmerk": [
+                "biologisch"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "np_lokaal": [
+                "nederland"
+              ],
+              "sp_exclude_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_exclude_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "sp_include_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "nutriscore": [
+                "C"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "np_versheid": [
+                "vers"
+              ],
+              "da_salted_or_not_salted": [
+                "Ongezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "da_fat_content": [
+                "Vol"
+              ],
+              "sp_include_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "np_puureerlij": [
+                "puur en eerlijk"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Vers"
+              ],
+              "sp_exclude_dieet_veganistisch": [
+                "Veganistisch"
+              ],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "sp_exclude_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "np_biologisch": [
+                "biologisch"
+              ],
+              "sp_include_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "sp_include_intolerance_geen_gluten": [
+                "Geen gluten"
+              ]
+            },
+            "isPreviouslyBought": true,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003e\u003cul\u003e\u003cli\u003eVolle melk van koeien die grazen op weilanden die alleen met natuurlijke middelen worden behandeld en biologisch voer krijgen\u003c/li\u003e\u003cli\u003eUitermate geschikt om romig cappuccinoschuim van te maken\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "\u003cp\u003e Neem het ervan en geniet van het lekkerste dat de natuur te bieden heeft. Van onze biologische producten kun je met een goed gevoel genieten dankzij de aandacht en inspanning van de boeren en producenten die ze voor ons maken. Natuurlijk worden al onze biologische producten onafhankelijk gecontroleerd en daarom verdienen ze het Europese keurmerk. Biologisch van Albert Heijn: dat smaakt naar meer!  \u003c/p\u003e\n  \u003cp\u003eZie je een weiland volop bloemen en bijen? Grote kans dat je naar een biologisch boerenbedrijf kijkt. De koeien van deze boerderijen zijn veel buiten, grazen op weilanden die alleen met natuurlijke middelen worden behandeld en krijgen biologisch voer. Dat voelt niet alleen goed, dat smaakt ook goed! Drink je graag romige cappuccino\u0026#8217;s, dan is volle melk de beste melk die je kunt kiezen. Het schuim geeft je koffie een zachte maar volle smaak. \u003c/p\u003e",
+            "isVirtualBundle": false,
+            "minBestBeforeDays": 6
+          },
+          "position": 18
+        },
+        {
+          "amount": 2,
+          "quantity": 2,
+          "allocatedQuantity": 2,
+          "product": {
+            "webshopId": 60746,
+            "hqId": 106377,
+            "title": "AH Biologisch Volle yoghurt",
+            "brand": "AH Biologisch",
+            "isSample": false,
+            "salesUnitSize": "1 l",
+            "unitPriceDescription": "normale prijs per liter €1.79",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313837333638?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313837333638?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313837333638?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313837333638?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313837333638?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 386491,
+            "hqPromotionId": 894383,
+            "bonusSegmentDescription": "PM BIO premium",
+            "extraDescriptions": [],
+            "discountType": "PO",
+            "promotionType": "PERSONAL",
+            "segmentType": "PREMIUM",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "10% KORTING",
+            "bonusStartDate": "2021-09-13",
+            "bonusEndDate": "2099-12-31",
+            "priceBeforeBonus": 1.79,
+            "currentPrice": 1.61,
+            "isBonusPrice": true,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 1383,
+            "multipleItemPromotion": false,
+            "labelType": "PREMIUM",
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_PERCENTAGE",
+                "defaultDescription": "10% korting",
+                "percentage": 10,
+                "precisePercentage": 10
+              }
+            ],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Zuivel, eieren",
+            "subCategory": "Volle yoghurt",
+            "subCategoryId": 1676,
+            "propertyIcons": [
+              "vega",
+              "lokaal",
+              "biologisch"
+            ],
+            "properties": {
+              "sp_exclude_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Geen toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "da_taste": [
+                "Yoghurt"
+              ],
+              "sp_include_dieet_vegetarisch": [
+                "Vegetarisch"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_kenmerk": [
+                "biologisch"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "np_verpakking": [
+                "gezinsverpakking"
+              ],
+              "np_lokaal": [
+                "nederland"
+              ],
+              "sp_exclude_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_exclude_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "sp_include_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "nutriscore": [
+                "B"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "da_salted_or_not_salted": [
+                "Ongezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "da_fat_content": [
+                "Vol"
+              ],
+              "sp_include_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "np_puureerlij": [
+                "puur en eerlijk"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Vers"
+              ],
+              "sp_exclude_dieet_veganistisch": [
+                "Veganistisch"
+              ],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "np_smaak": [
+                "naturel"
+              ],
+              "sp_exclude_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "np_biologisch": [
+                "biologisch"
+              ],
+              "sp_include_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "sp_include_intolerance_geen_gluten": [
+                "Geen gluten"
+              ]
+            },
+            "isPreviouslyBought": true,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003e\u003cul\u003e\u003cli\u003eGemaakt van melk van koeien die grazen op weilanden die alleen met natuurlijke middelen worden behandeld en biologisch voer krijgen\u003c/li\u003e\u003cli\u003eEen stevige yoghurt\u003c/li\u003e\u003cli\u003eHeel geschikt om sauzen mee te maken\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "\u003cp\u003e Neem het ervan en geniet van het lekkerste dat de natuur te bieden heeft. Van onze biologische producten kun je met een goed gevoel genieten dankzij de aandacht en inspanning van de boeren en producenten die ze voor ons maken. Natuurlijk worden al onze biologische producten onafhankelijk gecontroleerd en daarom verdienen ze het Europese keurmerk. Biologisch van Albert Heijn: dat smaakt naar meer!  \u003c/p\u003e\n  \u003cp\u003eZie je een weiland volop bloemen en bijen? Grote kans dat je naar een biologisch boerenbedrijf kijkt. De koeien van deze boerderijen zijn veel buiten, grazen op weilanden die alleen met natuurlijke middelen worden behandeld en krijgen biologisch voer. Dat voelt niet alleen goed, dat smaakt ook goed! Biologische volle yoghurt is stevige yoghurt. Ook heel geschikt om sauzen mee te maken. Gebruik deze bijvoorbeeld eens voor een zachte, romige kip-kerrie. \u003c/p\u003e",
+            "isVirtualBundle": false,
+            "minBestBeforeDays": 7
+          },
+          "position": 19
+        }
+      ]
+    },
+    {
+      "taxonomyName": "Pasta, rijst, wereldkeuken",
+      "orderedProducts": [
+        {
+          "amount": 2,
+          "quantity": 2,
+          "allocatedQuantity": 2,
+          "product": {
+            "webshopId": 199922,
+            "hqId": 797188,
+            "title": "AH Excellent Biologische kalamata olijf zonder pit",
+            "brand": "AH Excellent",
+            "isSample": false,
+            "salesUnitSize": "240 g",
+            "unitPriceDescription": "normale prijs per kg €16.85",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303234363831?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303234363831?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303234363831?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303234363831?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130303234363831?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 386491,
+            "hqPromotionId": 894383,
+            "bonusSegmentDescription": "PM BIO premium",
+            "extraDescriptions": [],
+            "discountType": "PO",
+            "promotionType": "PERSONAL",
+            "segmentType": "PREMIUM",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "10% KORTING",
+            "bonusStartDate": "2021-09-13",
+            "bonusEndDate": "2099-12-31",
+            "priceBeforeBonus": 2.19,
+            "currentPrice": 1.97,
+            "isBonusPrice": true,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 1383,
+            "multipleItemPromotion": false,
+            "labelType": "PREMIUM",
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_PERCENTAGE",
+                "defaultDescription": "10% korting",
+                "percentage": 10,
+                "precisePercentage": 10
+              }
+            ],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Pasta, rijst, wereldkeuken",
+            "subCategory": "Zwarte olijven",
+            "subCategoryId": 2225,
+            "propertyIcons": [
+              "vegan",
+              "biologisch"
+            ],
+            "properties": {
+              "sp_include_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Geen toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "sp_include_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "da_taste": [
+                "Olijf"
+              ],
+              "sp_include_dieet_vegetarisch": [
+                "Vegetarisch"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_kenmerk": [
+                "biologisch"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "np_verpakking": [
+                "pot"
+              ],
+              "sp_exclude_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "da_processing_type": [
+                "Pitloos"
+              ],
+              "sp_include_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "sp_include_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "nutriscore": [
+                "C"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "sp_include_dieet_veganistisch": [
+                "Veganistisch"
+              ],
+              "da_salted_or_not_salted": [
+                "Gezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_exclude_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "da_free_of_sugar": [
+                "Ja"
+              ],
+              "da_store_department": [
+                "Houdbaar"
+              ],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "da_type_of_processed_food": [
+                "Pitloos"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "np_biologisch": [
+                "biologisch"
+              ],
+              "sp_include_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "np_soort": [
+                "heel"
+              ],
+              "sp_include_intolerance_geen_gluten": [
+                "Geen gluten"
+              ]
+            },
+            "isPreviouslyBought": true,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003e\u003cul\u003e\u003cli\u003eZonder pit\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "\u003cp\u003e Neem het ervan en geniet van het lekkerste dat de natuur te bieden heeft. Van onze biologische producten kun je met een goed gevoel genieten dankzij de aandacht en inspanning van de boeren en producenten die ze voor ons maken. Natuurlijk worden al onze biologische producten onafhankelijk gecontroleerd en daarom verdienen ze het Europese keurmerk. Biologisch van Albert Heijn: dat smaak naar meer!  \u003c/p\u003e",
+            "isVirtualBundle": false
+          },
+          "position": 8
+        },
+        {
+          "amount": 1,
+          "quantity": 1,
+          "allocatedQuantity": 1,
+          "product": {
+            "webshopId": 521819,
+            "hqId": 72476,
+            "title": "Chupa Chups Strawberry \u0026 cream flavour",
+            "brand": "Chupa Chups",
+            "isSample": false,
+            "salesUnitSize": "250 ml",
+            "unitPriceDescription": "normale prijs per liter €4.76",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_43545239393338333439?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_43545239393338333439?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_43545239393338333439?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_43545239393338333439?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_43545239393338333439?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 761574,
+            "hqPromotionId": 150554,
+            "bonusSegmentDescription": "Chupa Chups Strawberry \u0026 cream flavour",
+            "extraDescriptions": [],
+            "discountType": "PO",
+            "promotionType": "PERSONAL",
+            "segmentType": "DIGITAL_SCRATCH_CARD",
+            "activationStatus": "REDEEMABLE",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "1 gratis",
+            "bonusStartDate": "2026-02-02",
+            "bonusEndDate": "2026-03-01",
+            "isBonusPrice": true,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 1,
+            "multipleItemPromotion": true,
+            "labelType": "SCRATCH_SUMMER",
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_SCRATCH_CARD",
+                "defaultDescription": "1 gratis",
+                "count": 1
+              }
+            ],
+            "redemptionCount": 1,
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Pasta, rijst, wereldkeuken",
+            "subCategory": "Surinaams, Antiliaans fris",
+            "subCategoryId": 20920,
+            "propertyIcons": [],
+            "properties": {
+              "sp_exclude_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "sp_exclude_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "da_taste": [
+                "Aardbei"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "sp_exclude_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_include_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "nutriscore": [
+                "E"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "np_zomerkras": [
+                "Zomerkrasfeest"
+              ],
+              "da_salted_or_not_salted": [
+                "Ongezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_include_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "sp_include_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Houdbaar"
+              ],
+              "da_carbonation_intensity": [
+                "bruisend"
+              ],
+              "da_grape": [],
+              "sp_exclude_dieet_veganistisch": [
+                "Veganistisch"
+              ],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "sp_exclude_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "sp_exclude_dieet_vegetarisch": [
+                "Vegetarisch"
+              ],
+              "sp_include_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "sp_include_intolerance_geen_gluten": [
+                "Geen gluten"
+              ]
+            },
+            "isPreviouslyBought": false,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003eChupa Chups frisdrank met de heerlijke smaak van de bekende lolly's\u003c/p\u003e\u003cp\u003e\u003cul\u003e\u003cli\u003eEen feel good frsdrank om je dag op te fleuren\u003c/li\u003e\u003cli\u003eEen frisdrank met de smaak van zuivel en aardbei\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "",
+            "isVirtualBundle": false
+          },
+          "position": 10
+        },
+        {
+          "amount": 1,
+          "quantity": 1,
+          "allocatedQuantity": 1,
+          "product": {
+            "webshopId": 62414,
+            "hqId": 524612,
+            "title": "AH Biologisch Schelpjes pasta",
+            "brand": "AH Biologisch",
+            "isSample": false,
+            "salesUnitSize": "500 g",
+            "unitPriceDescription": "normale prijs per kg €2.78",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_43545239393232353639?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_43545239393232353639?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_43545239393232353639?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_43545239393232353639?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_43545239393232353639?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 386491,
+            "hqPromotionId": 894383,
+            "bonusSegmentDescription": "PM BIO premium",
+            "extraDescriptions": [],
+            "discountType": "PO",
+            "promotionType": "PERSONAL",
+            "segmentType": "PREMIUM",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "10% KORTING",
+            "bonusStartDate": "2021-09-13",
+            "bonusEndDate": "2099-12-31",
+            "priceBeforeBonus": 1.39,
+            "currentPrice": 1.25,
+            "isBonusPrice": true,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 1383,
+            "multipleItemPromotion": false,
+            "labelType": "PREMIUM",
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_PERCENTAGE",
+                "defaultDescription": "10% korting",
+                "percentage": 10,
+                "precisePercentage": 10
+              }
+            ],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Pasta, rijst, wereldkeuken",
+            "subCategory": "Schelpjes, conchigliette, orecchiette",
+            "subCategoryId": 9639,
+            "propertyIcons": [
+              "vegan",
+              "biologisch"
+            ],
+            "properties": {
+              "sp_exclude_intolerance_geen_gluten": [
+                "Geen gluten"
+              ],
+              "sp_include_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Geen toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "sp_include_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "sp_include_dieet_vegetarisch": [
+                "Vegetarisch"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_kenmerk": [
+                "biologisch"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "da_a_type_of_preparation_cookware": [
+                "Pan"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "sp_include_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "nutriscore": [
+                "A"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "sp_include_dieet_veganistisch": [
+                "Veganistisch"
+              ],
+              "da_salted_or_not_salted": [
+                "Ongezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_include_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "sp_include_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "np_puureerlij": [
+                "puur en eerlijk"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Houdbaar"
+              ],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "np_smaak": [
+                "naturel"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "sp_exclude_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "np_biologisch": [
+                "biologisch"
+              ],
+              "sp_include_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "np_soort": [
+                "macaroni"
+              ],
+              "da_type_of_grain": [
+                "Durum",
+                "Tarwe",
+                "Rijst"
+              ],
+              "sp_exclude_intolerance_geen_eieren": [
+                "Geen eieren"
+              ]
+            },
+            "isPreviouslyBought": true,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003e\u003cul\u003e\u003cli\u003eDe tarwe voor deze pastaschelpjes is op geheel natuurlijke wijze geteeld.\u003c/li\u003e\u003cli\u003eVrij van kunstmatige toevoegingen\u003c/li\u003e\u003cli\u003eDe perfecte vorm voor een pastasalade\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "",
+            "isVirtualBundle": false
+          },
+          "position": 17
+        }
+      ]
+    },
+    {
+      "taxonomyName": "Diepvries",
+      "orderedProducts": [
+        {
+          "amount": 1,
+          "quantity": 1,
+          "allocatedQuantity": 1,
+          "product": {
+            "webshopId": 409996,
+            "hqId": 854211,
+            "title": "AH Biologisch Boerenkool deelblokjes",
+            "brand": "AH Biologisch",
+            "isSample": false,
+            "salesUnitSize": "450 g",
+            "unitPriceDescription": "normale prijs per kg €2.78",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_434d50313933323730?revLabel=3\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_434d50313933323730?revLabel=3\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_434d50313933323730?revLabel=3\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_434d50313933323730?revLabel=3\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_434d50313933323730?revLabel=3\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 386491,
+            "hqPromotionId": 894383,
+            "bonusSegmentDescription": "PM BIO premium",
+            "extraDescriptions": [],
+            "discountType": "PO",
+            "promotionType": "PERSONAL",
+            "segmentType": "PREMIUM",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "10% KORTING",
+            "bonusStartDate": "2021-09-13",
+            "bonusEndDate": "2099-12-31",
+            "priceBeforeBonus": 1.25,
+            "currentPrice": 1.12,
+            "isBonusPrice": true,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 1383,
+            "multipleItemPromotion": false,
+            "labelType": "PREMIUM",
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_PERCENTAGE",
+                "defaultDescription": "10% korting",
+                "percentage": 10,
+                "precisePercentage": 10
+              }
+            ],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Diepvries",
+            "subCategory": "Boerenkool (diepvries)",
+            "subCategoryId": 44078,
+            "propertyIcons": [
+              "vegan",
+              "biologisch",
+              "diepvries"
+            ],
+            "properties": {
+              "sp_include_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Geen toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "sp_include_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "da_taste": [
+                "Boerenkool"
+              ],
+              "sp_include_dieet_vegetarisch": [
+                "Vegetarisch"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_kenmerk": [
+                "biologisch"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "diepvries": [
+                "Y"
+              ],
+              "da_a_type_of_preparation_cookware": [
+                "Magnetron",
+                "Pan"
+              ],
+              "sp_include_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "sp_include_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "nutriscore": [
+                "A"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "sp_include_dieet_veganistisch": [
+                "Veganistisch"
+              ],
+              "da_salted_or_not_salted": [
+                "Ongezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_include_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "sp_include_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Diepvries"
+              ],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "np_biologisch": [
+                "biologisch"
+              ],
+              "sp_include_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "sp_include_intolerance_geen_gluten": [
+                "Geen gluten"
+              ]
+            },
+            "isPreviouslyBought": false,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003eVriesverse biologische boerenkool in deelblokjes. Ideaal voor een snelle stamppot.\u003c/p\u003e\u003cp\u003e\u003cul\u003e\u003cli\u003eZo makkelijk kan lekker eten zijn!\u003c/li\u003e\u003cli\u003eDirect na de oogst geblancheerd en ingevroren\u003c/li\u003e\u003cli\u003eMet behoud van smaak, vitamines en voedingsstoffen\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "",
+            "isVirtualBundle": false
+          },
+          "position": 16
+        }
+      ]
+    },
+    {
+      "taxonomyName": "Frisdrank, sappen, water",
+      "orderedProducts": [
+        {
+          "amount": 1,
+          "quantity": 1,
+          "allocatedQuantity": 1,
+          "product": {
+            "webshopId": 530999,
+            "hqId": 49051,
+            "title": "Karvan Cévitam Original sinaasappel siroop",
+            "brand": "Karvan Cévitam",
+            "isSample": false,
+            "salesUnitSize": "0,6 l",
+            "unitPriceDescription": "prijs per liter €7.15",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_344d707a596c76615178614455514c4d517944743741?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_344d707a596c76615178614455514c4d517944743741?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_344d707a596c76615178614455514c4d517944743741?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_344d707a596c76615178614455514c4d517944743741?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_344d707a596c76615178614455514c4d517944743741?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "extraDescriptions": [],
+            "isInfiniteBonus": false,
+            "priceBeforeBonus": 4.29,
+            "isStapelBonus": false,
+            "isBonus": false,
+            "discountLabels": [],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Frisdrank, sappen, water",
+            "subCategory": "Limonadesiroop",
+            "subCategoryId": 1523,
+            "propertyIcons": [
+              "vegan"
+            ],
+            "properties": {
+              "sp_include_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "da_taste": [
+                "Appel",
+                "Sinaasappel"
+              ],
+              "sp_include_dieet_vegetarisch": [
+                "Vegetarisch"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "sp_include_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "sp_include_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "nutriscore": [
+                "E"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "sp_include_dieet_veganistisch": [
+                "Veganistisch"
+              ],
+              "da_salted_or_not_salted": [
+                "Ongezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_include_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "sp_include_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Houdbaar"
+              ],
+              "da_grape": [],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "sp_exclude_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "sp_include_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "sp_include_intolerance_geen_gluten": [
+                "Geen gluten"
+              ]
+            },
+            "isPreviouslyBought": false,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003eMaak meer van je water met de Karvan Cevitam siropen. Onze dynamische combinaties van fruit helpen jou om je water een heerlijke smaak te geven. Verras jezelf!\u003c/p\u003e\u003cp\u003e\u003cul\u003e\u003cli\u003e100% natuurlijke smaak\u003c/li\u003e\u003cli\u003eBron van vitamine c met 75% fruit\u003c/li\u003e\u003cli\u003eGeen kleur-, en kunstmatige smaakstoffen\u003c/li\u003e\u003cli\u003e30 glazen limonade per fles\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "Met de sinaasappel limonadesiroop van Karvan Cevitam maak je in een handomdraai een lekkere dorstlesser met wel 75% fruit! Voor heerlijk fruitig water met de smaak van sinaasappel meng je 1 deel siroop op 9 delen water. Laat je fantasie de vrije loop door deze siroop te mengen met bruiswater voor je eigen limo met een twist of voeg een klein scheutje siroop toe aan je favoriete mocktail, lekker voor bij de zomerse bbq! Karvan Cevitam bevat geen kleurstoffen-, en kunstmatige smaakstoffen. Bovendien is het een bron van vitamine c. Nu met 100% natuurlijke smaak! 1 fles maakt tot wel 6 liter limonade. Dit zijn 30 glazen verfrissende limo!",
+            "isVirtualBundle": false
+          },
+          "position": 5
+        },
+        {
+          "amount": 1,
+          "quantity": 1,
+          "allocatedQuantity": 1,
+          "product": {
+            "webshopId": 589322,
+            "hqId": 34365,
+            "title": "Let it Bio Gember citroen siroop",
+            "brand": "Let it Bio",
+            "isSample": false,
+            "salesUnitSize": "0,5 l",
+            "unitPriceDescription": "normale prijs per liter €7.98",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_695179324a6e57335354613939677970454f76364a51?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_695179324a6e57335354613939677970454f76364a51?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_695179324a6e57335354613939677970454f76364a51?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_695179324a6e57335354613939677970454f76364a51?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_695179324a6e57335354613939677970454f76364a51?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "bonusSegmentId": 386491,
+            "hqPromotionId": 894383,
+            "bonusSegmentDescription": "PM BIO premium",
+            "extraDescriptions": [],
+            "discountType": "PO",
+            "promotionType": "PERSONAL",
+            "segmentType": "PREMIUM",
+            "isInfiniteBonus": false,
+            "bonusMechanism": "10% KORTING",
+            "bonusStartDate": "2021-09-13",
+            "bonusEndDate": "2099-12-31",
+            "priceBeforeBonus": 3.99,
+            "currentPrice": 3.59,
+            "isBonusPrice": true,
+            "isStapelBonus": false,
+            "isBonus": true,
+            "hasListPrice": false,
+            "productCount": 1383,
+            "multipleItemPromotion": false,
+            "labelType": "PREMIUM",
+            "discountLabels": [
+              {
+                "code": "DISCOUNT_PERCENTAGE",
+                "defaultDescription": "10% korting",
+                "percentage": 10,
+                "precisePercentage": 10
+              }
+            ],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Frisdrank, sappen, water",
+            "subCategory": "Limonadesiroop",
+            "subCategoryId": 1523,
+            "propertyIcons": [
+              "vegan",
+              "biologisch"
+            ],
+            "properties": {
+              "sp_include_intolerance_geen_melk": [
+                "Geen melk"
+              ],
+              "sp_include_intolerance_geen_kreeftachtigen": [
+                "Geen kreeftachtigen (schaaldieren)"
+              ],
+              "sp_include_intolerance_geen_soja": [
+                "Geen soja"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Toegevoegde suikers"
+              ],
+              "sp_include_intolerance_geen_vis": [
+                "Geen vis"
+              ],
+              "da_taste": [
+                "Appel",
+                "Citroen",
+                "Druif",
+                "Gember",
+                "Limoen"
+              ],
+              "sp_include_dieet_vegetarisch": [
+                "Vegetarisch"
+              ],
+              "sp_include_intolerance_geen_lupine": [
+                "Geen lupine"
+              ],
+              "sp_kenmerk": [
+                "biologisch"
+              ],
+              "sp_include_intolerance_geen_pindas": [
+                "Geen pinda's"
+              ],
+              "sp_include_intolerance_geen_mosterd": [
+                "Geen mosterd"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "sp_include_intolerance_geen_lactose": [
+                "Geen lactose"
+              ],
+              "nutriscore": [
+                "D"
+              ],
+              "sp_include_intolerance_geen_sulfiet": [
+                "Geen sulfiet"
+              ],
+              "sp_include_dieet_veganistisch": [
+                "Veganistisch"
+              ],
+              "da_salted_or_not_salted": [
+                "Ongezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ],
+              "sp_include_intolerance_geen_sesam": [
+                "Geen sesam"
+              ],
+              "sp_include_dieet_laag_vet": [
+                "Laag vet"
+              ],
+              "sp_include_dieet_laag_zout": [
+                "Laag zout"
+              ],
+              "da_free_of_sugar": [
+                "Nee"
+              ],
+              "da_store_department": [
+                "Houdbaar"
+              ],
+              "da_carbonation_intensity": [
+                "niet bruisend"
+              ],
+              "da_grape": [],
+              "sp_include_intolerance_geen_schelpdieren": [
+                "Geen schelpdieren (schaaldieren)"
+              ],
+              "sp_exclude_dieet_laag_suiker": [
+                "Laag suiker"
+              ],
+              "sp_include_intolerance_geen_eieren": [
+                "Geen eieren"
+              ],
+              "sp_include_intolerance_geen_noten": [
+                "Geen noten"
+              ],
+              "np_biologisch": [
+                "biologisch"
+              ],
+              "sp_include_intolerance_geen_selderij": [
+                "Geen selderij"
+              ],
+              "sp_include_intolerance_geen_gluten": [
+                "Geen gluten"
+              ]
+            },
+            "isPreviouslyBought": false,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003eVoor het maken van biologische limonade maar ook onverdund te gebruiken in een cocktail, pudding, yoghurt, over ijs of als ingredient in een dressing.\u003c/p\u003e\u003cp\u003e\u003cul\u003e\u003cli\u003eBevat 25% biologisch vruchtensap en natuurlijk extract en aroma\u003c/li\u003e\u003cli\u003eVerdun 1 deel siroop met 9 delen (koolzuurhoudend) water\u003c/li\u003e\u003cli\u003eBevat geen kunstmatige geur-, kleur- en smaakstoffen\u003c/li\u003e\u003cli\u003eBevat biologische en natuurlijke ingredienten\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "",
+            "isVirtualBundle": false
+          },
+          "position": 6
+        }
+      ]
+    },
+    {
+      "taxonomyName": "Huishouden",
+      "orderedProducts": [
+        {
+          "amount": 2,
+          "quantity": 2,
+          "allocatedQuantity": 2,
+          "product": {
+            "webshopId": 63072,
+            "hqId": 527965,
+            "title": "Komo Trekbandzakken 60 liter",
+            "brand": "Komo",
+            "isSample": false,
+            "salesUnitSize": "15 stuks",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_434d50313037343435?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_434d50313037343435?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_434d50313037343435?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_434d50313037343435?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_434d50313037343435?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "extraDescriptions": [],
+            "isInfiniteBonus": false,
+            "priceBeforeBonus": 1.99,
+            "isStapelBonus": false,
+            "isBonus": false,
+            "discountLabels": [],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Huishouden",
+            "subCategory": "Treksluitzakken",
+            "subCategoryId": 1621,
+            "propertyIcons": [],
+            "properties": {
+              "da_store_department": [
+                "Non Food"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ]
+            },
+            "isPreviouslyBought": true,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003eGemaakt van gebruikt plastic papieren wikkel kan bij het oud papier\u003c/p\u003e\u003cp\u003e\u003cul\u003e\u003cli\u003ehogere vulcapaciteit dan normale afvalzak\u003c/li\u003e\u003cli\u003emet trekbandsluiting\u003c/li\u003e\u003cli\u003eKomo -keurmerk = gecontroleerde kwaliteit\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "papieren wikkel kan bij het oud papier",
+            "isVirtualBundle": false
+          },
+          "position": 2
+        },
+        {
+          "amount": 1,
+          "quantity": 1,
+          "allocatedQuantity": 1,
+          "product": {
+            "webshopId": 595094,
+            "hqId": 43281,
+            "title": "AH Toiletpapier zacht 4-laags 12=18 rollen",
+            "brand": "AH",
+            "isSample": false,
+            "salesUnitSize": "12 stuks",
+            "images": [
+              {
+                "width": 800,
+                "height": 800,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313532323930?revLabel=1\u0026rendition=800x800_JPG_Q90\u0026fileType=binary"
+              },
+              {
+                "width": 400,
+                "height": 400,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313532323930?revLabel=1\u0026rendition=400x400_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 200,
+                "height": 200,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313532323930?revLabel=1\u0026rendition=200x200_JPG_Q85\u0026fileType=binary"
+              },
+              {
+                "width": 48,
+                "height": 48,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313532323930?revLabel=1\u0026rendition=48x48_GIF\u0026fileType=binary"
+              },
+              {
+                "width": 80,
+                "height": 80,
+                "url": "https://static.ah.nl/dam/product/AHI_4354523130313532323930?revLabel=1\u0026rendition=80x80_JPG\u0026fileType=binary"
+              }
+            ],
+            "extraDescriptions": [],
+            "isInfiniteBonus": false,
+            "priceBeforeBonus": 8.49,
+            "isStapelBonus": false,
+            "isBonus": false,
+            "discountLabels": [],
+            "shopType": "AH",
+            "orderAvailabilityStatus": "IN_ASSORTMENT",
+            "availableOnline": true,
+            "isOrderable": true,
+            "mainCategory": "Huishouden",
+            "subCategory": "Toiletpapier - 4 en 5 laags",
+            "subCategoryId": 2045,
+            "propertyIcons": [
+              "goedkoopje"
+            ],
+            "properties": {
+              "da_accreditation": [
+                "EU_ECO_LABEL"
+              ],
+              "da_store_department": [
+                "Non Food"
+              ],
+              "da_sugar_added_or_no_sugar_added": [
+                "Geen toegevoegde suikers"
+              ],
+              "da_toilet_paper_layers": [
+                "4"
+              ],
+              "da_available_in_store": [
+                "true"
+              ],
+              "np_goedkoopje": [
+                "prijsfavoriet"
+              ],
+              "da_salted_or_not_salted": [
+                "Ongezouten"
+              ],
+              "da_excluded_assortment": [
+                "false"
+              ]
+            },
+            "isPreviouslyBought": false,
+            "nix18": false,
+            "descriptionHighlights": "\u003cp\u003e\u003cul\u003e\u003cli\u003ePrijsfavorieten: topkwaliteit en altijd laaggeprijsd\u003c/li\u003e\u003c/ul\u003e\u003c/p\u003e",
+            "descriptionFull": "\u003cp\u003eDit product is een Prijsfavoriet. Dat zijn onze eigen-merkproducten van topkwaliteit en ze zijn altijd voordelig. Je herkent ze aan het blauwe duimpje.\u003c/p\u003e",
+            "isVirtualBundle": false
+          },
+          "position": 7
+        }
+      ]
+    }
+  ],
+  "cancellable": true,
+  "orderPayments": [],
+  "address": {
+    "street": "Voorbeeldstraat",
+    "houseNumber": 1,
+    "zipCode": 1234,
+    "zipCodeExtra": "AB",
+    "city": "AMSTERDAM",
+    "countryCode": "NLD",
+    "type": "H"
+  },
+  "orderMethod": "PLANSERVICE",
+  "reopenable": true
+}


### PR DESCRIPTION
## Summary
- Add `order` command: bare lists open orders, `show` order contents, `add` products by ID or search, `rm` products (reopens submitted orders automatically)
- Add `list` command: bare lists shopping lists with UUIDs, `show` items, `add` products with quantity, `rm` by product ID
- Add `search` command for product search with tabular output
- Standardize all resource commands to consistent `<resource> [show|add|rm] <id>` pattern
- Fix `AddToFavoriteList` to send quantity field
- Replace broken REST item removal with GraphQL `favoriteListProductsDeleteV2`
- Fix `GetProductsByIDs` response decoding (bare array, not wrapped object)
- Fix `getShoppingList` to populate items via GraphQL

## CLI conventions

```
appie <resource>                              Overview (list all, showing IDs)
appie <resource> show <target>                Detail view
appie <resource> add <target> <item> [flags]  Add to target
appie <resource> rm <target> <item>           Remove from target
```

## Test plan
- [x] Unit tests for `findList` exact UUID match and rejection of prefixes
- [x] Unit tests for order details parsing (`order_test.go`)
- [x] Unit tests for shopping list items and list fetching (`shoppinglist_test.go`)
- [x] Integration test for shopping list items (`TestGetShoppingListItems`)
- [x] Manual: `appie order`, `appie order show <id>`, `appie order add <id> <product>`, `appie order rm <id> <product-id>`
- [x] Manual: `appie list`, `appie list show <uuid>`, `appie list add <uuid> <product> -n 3`, `appie list rm <uuid> <product-id>`
- [x] Manual: `appie receipt`, `appie receipt show <txn-id>`
- [x] Manual: `appie search <query>`