### PR TITLE
feat: resolve POS-receipt productId to webshop productId

### DIFF
--- a/cmd/appie/receipt.go
+++ b/cmd/appie/receipt.go
@@ -95,10 +95,14 @@ func showReceipt(ctx context.Context, client *appie.Client, id string) error {
 	var subtotal float64
 	for _, item := range receipt.Items {
 		subtotal += item.Amount
+		wi := ""
+		if item.WebshopID > 0 {
+			wi = fmt.Sprintf("  wi%d", item.WebshopID)
+		}
 		if item.Quantity > 1 {
-			fmt.Printf("  %dx %-30s %6.2f\n", item.Quantity, item.Description, item.Amount)
+			fmt.Printf("  %dx %-30s %6.2f%s\n", item.Quantity, item.Description, item.Amount, wi)
 		} else {
-			fmt.Printf("     %-30s %6.2f\n", item.Description, item.Amount)
+			fmt.Printf("     %-30s %6.2f%s\n", item.Description, item.Amount, wi)
 		}
 	}
 

--- a/doc/albertheijn_api.md
+++ b/doc/albertheijn_api.md
@@ -749,6 +749,7 @@ apollographql-client-version: 9.28-260102201630
 | FetchRecipes | Recipe search | |
 | FetchTotalPrice | Calculate order total price | |
 | SearchProducts | Product search with facets/variants (no bonus mechanism) | ✅ |
+| productConvertId | Resolve POS-receipt productId → webshop productId | ✅ Implemented |
 | FetchEntryPoints | Home screen entry points | |
 | FetchCuratedLists | Curated shopping lists | |
 | FetchNBACard | Next best action card | |
@@ -1143,6 +1144,30 @@ fragment SearchProductFragment on Product {
   }
 }
 ```
+
+#### productConvertId
+
+Resolves the POS-side `productId` printed on a kassabon (`PosReceiptProduct.id`) to the AH webshop product id (the `wi<id>` slug used on ah.nl). Required because `PosReceiptProduct.externalIds` is declared but always `null` in production, and the two id spaces are distinct (e.g. `https://www.ah.nl/producten/product/wi767898` returns "product bestaat niet"; the actual webshop id for that POS line is `171607`).
+
+**Signature:** `productConvertId(sourceId: Int!): Int`
+
+Returns the webshop product id, or `-1` when no conversion exists (for example when the input is already a webshop id). The resolver does **not** validate the source id space — passing an arbitrary integer can yield a real but unrelated webshop id, so only feed it ids that came from `PosReceiptProduct.id`.
+
+GraphQL aliases let callers resolve a whole kassabon in one round-trip:
+
+```graphql
+query Convert {
+  p0: productConvertId(sourceId: 767898)
+  p1: productConvertId(sourceId: 823326)
+  p2: productConvertId(sourceId: 552022)
+}
+```
+
+```json
+{ "data": { "p0": 171607, "p1": 231878, "p2": 121453 } }
+```
+
+Wrapped in Go as `Client.ConvertPOSIDs(ctx, []int) (map[int]int, error)`; `Client.GetReceipt` calls it automatically and populates `ReceiptItem.WebshopID`.
 
 #### FetchEntryPoints
 

--- a/receipt_test.go
+++ b/receipt_test.go
@@ -58,6 +58,31 @@ func TestGetReceiptIntegration(t *testing.T) {
 			t.Logf("  ... and %d more items", len(receipt.Items)-5)
 			break
 		}
-		t.Logf("    - %s: %.2f EUR (qty: %d)", item.Description, item.Amount, item.Quantity)
+		t.Logf("    - %s: %.2f EUR (qty: %d) wi=%d", item.Description, item.Amount, item.Quantity, item.WebshopID)
+	}
+
+	var resolved int
+	for _, item := range receipt.Items {
+		if item.WebshopID > 0 {
+			resolved++
+		}
+	}
+	if resolved == 0 {
+		t.Errorf("expected at least one ReceiptItem to have WebshopID > 0, got 0 of %d", len(receipt.Items))
+	}
+
+	for _, item := range receipt.Items {
+		if item.WebshopID == 0 {
+			continue
+		}
+		product, err := client.GetProduct(ctx, item.WebshopID)
+		if err != nil {
+			t.Fatalf("GetProduct(wi%d) for kassabon line %q: %v", item.WebshopID, item.Description, err)
+		}
+		if product.Title == "" {
+			t.Errorf("GetProduct(wi%d) returned empty title", item.WebshopID)
+		}
+		t.Logf("  resolved %d (%s) -> wi%d (%s)", item.ProductID, item.Description, item.WebshopID, product.Title)
+		break
 	}
 }

--- a/receipts.go
+++ b/receipts.go
@@ -3,6 +3,7 @@ package appie
 import (
 	"context"
 	"fmt"
+	"strings"
 )
 
 const fetchPosReceiptsQuery = `query FetchPosReceipts($offset: Int!, $limit: Int!) {
@@ -156,10 +157,83 @@ func (c *Client) GetReceipt(ctx context.Context, id string) (*Receipt, error) {
 		})
 	}
 
+	posIDs := make([]int, 0, len(items))
+	for _, it := range items {
+		posIDs = append(posIDs, it.ProductID)
+	}
+	if mapping, err := c.ConvertPOSIDs(ctx, posIDs); err != nil {
+		c.logger.Printf("ConvertPOSIDs: %v (continuing without webshop ids)", err)
+	} else {
+		for i := range items {
+			items[i].WebshopID = mapping[items[i].ProductID]
+		}
+	}
+
 	return &Receipt{
 		TransactionID: details.ID,
 		Items:         items,
 		Discounts:     discounts,
 		Payments:      payments,
 	}, nil
+}
+
+// ConvertPOSIDs maps POS-receipt productIds (the integer found on
+// PosReceiptProduct.id / ReceiptItem.ProductID) to AH webshop product ids
+// (the "wi<id>" used on ah.nl). Resolution happens in a single GraphQL
+// request using aliased subfields, regardless of how many ids are passed.
+//
+// The returned map only contains entries that resolved successfully.
+// Unknown ids and ids for which the API returned -1 (its sentinel for "no
+// conversion exists") are silently omitted, so callers can use a plain
+// `out[id]` lookup with a `0` zero-value meaning "unresolved".
+//
+// Only feed this method ids that actually came from PosReceiptProduct.id.
+// The underlying resolver does not validate the source id space; passing
+// arbitrary integers can return real but unrelated webshop ids.
+func (c *Client) ConvertPOSIDs(ctx context.Context, ids []int) (map[int]int, error) {
+	out := make(map[int]int)
+	if len(ids) == 0 {
+		return out, nil
+	}
+
+	seen := make(map[int]struct{}, len(ids))
+	unique := make([]int, 0, len(ids))
+	for _, id := range ids {
+		if id <= 0 {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		unique = append(unique, id)
+	}
+	if len(unique) == 0 {
+		return out, nil
+	}
+
+	// Aliases must be static identifiers, so the ids are inlined into
+	// the query string rather than passed as variables. They originate
+	// from the AH API itself (PosReceiptProduct.id) and the dedupe loop
+	// above guarantees they are positive integers — no injection surface.
+	var b strings.Builder
+	b.WriteString("query Convert {")
+	for i, id := range unique {
+		fmt.Fprintf(&b, " p%d: productConvertId(sourceId: %d)", i, id)
+	}
+	b.WriteString(" }")
+
+	var resp map[string]int
+	if err := c.DoGraphQL(ctx, b.String(), nil, &resp); err != nil {
+		return nil, fmt.Errorf("convert pos ids: %w", err)
+	}
+
+	for i, id := range unique {
+		v, ok := resp[fmt.Sprintf("p%d", i)]
+		if !ok || v <= 0 {
+			continue
+		}
+		out[id] = v
+	}
+	return out, nil
 }

--- a/receipts.go
+++ b/receipts.go
@@ -183,9 +183,11 @@ func (c *Client) GetReceipt(ctx context.Context, id string) (*Receipt, error) {
 // request using aliased subfields, regardless of how many ids are passed.
 //
 // The returned map only contains entries that resolved successfully.
-// Unknown ids and ids for which the API returned -1 (its sentinel for "no
-// conversion exists") are silently omitted, so callers can use a plain
-// `out[id]` lookup with a `0` zero-value meaning "unresolved".
+// Unknown ids, ids for which the API returned its -1 "no conversion"
+// sentinel, and ids whose alias came back null are silently omitted, so
+// callers can use a plain `out[id]` lookup with a `0` zero-value meaning
+// "unresolved". The map is always non-nil (including on error), so it is
+// safe to read from even when the caller chooses to ignore err.
 //
 // Only feed this method ids that actually came from PosReceiptProduct.id.
 // The underlying resolver does not validate the source id space; passing
@@ -223,17 +225,20 @@ func (c *Client) ConvertPOSIDs(ctx context.Context, ids []int) (map[int]int, err
 	}
 	b.WriteString(" }")
 
-	var resp map[string]int
+	// productConvertId is declared as Int (nullable) in the schema —
+	// decode through *int so a null alias becomes a normal "unresolved"
+	// instead of a JSON unmarshal failure that would torch the batch.
+	var resp map[string]*int
 	if err := c.DoGraphQL(ctx, b.String(), nil, &resp); err != nil {
-		return nil, fmt.Errorf("convert pos ids: %w", err)
+		return out, fmt.Errorf("convert pos ids: %w", err)
 	}
 
 	for i, id := range unique {
-		v, ok := resp[fmt.Sprintf("p%d", i)]
-		if !ok || v <= 0 {
+		v := resp[fmt.Sprintf("p%d", i)]
+		if v == nil || *v <= 0 {
 			continue
 		}
-		out[id] = v
+		out[id] = *v
 	}
 	return out, nil
 }

--- a/receipts_test.go
+++ b/receipts_test.go
@@ -3,8 +3,10 @@ package appie
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -158,5 +160,143 @@ func TestGetReceipt(t *testing.T) {
 	}
 	if receipt.Payments[0].Amount != 5.07 {
 		t.Errorf("got payment amount %.2f, want 5.07", receipt.Payments[0].Amount)
+	}
+}
+
+// receiptDetailsFixture is the GraphQL data block returned by the
+// posReceiptDetails query in the resolver-aware tests below.
+const receiptDetailsFixture = `{
+	"posReceiptDetails": {
+		"id": "txn-001",
+		"products": [
+			{"id": 767898, "quantity": 3, "name": "COCA-COLA",   "price": {"amount": 2.49}, "amount": {"amount": 7.47}},
+			{"id": 823326, "quantity": 1, "name": "AH KWARK",    "price": {"amount": 1.49}, "amount": {"amount": 1.49}},
+			{"id": 552022, "quantity": 1, "name": "AH ZALMFILET","price": {"amount": 5.99}, "amount": {"amount": 5.99}},
+			{"id": 999999, "quantity": 1, "name": "UNRESOLVABLE","price": {"amount": 0.99}, "amount": {"amount": 0.99}}
+		],
+		"discounts": [],
+		"payments":  []
+	}
+}`
+
+// readGraphQLRequest reads and rewinds the body so the handler can both
+// inspect and decode the request.
+func readGraphQLRequest(t *testing.T, r *http.Request) (graphQLRequest, string) {
+	t.Helper()
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	var req graphQLRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	return req, string(raw)
+}
+
+func TestGetReceiptResolvesWebshopID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/graphql" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		req, _ := readGraphQLRequest(t, r)
+
+		var data string
+		switch {
+		case strings.Contains(req.Query, "posReceiptDetails"):
+			data = receiptDetailsFixture
+		case strings.Contains(req.Query, "productConvertId"):
+			// Mirror the production behaviour: 999999 has no
+			// conversion (sentinel -1); the others resolve.
+			data = `{"p0":171607,"p1":231878,"p2":121453,"p3":-1}`
+		default:
+			t.Fatalf("unexpected query: %s", req.Query)
+		}
+		json.NewEncoder(w).Encode(graphQLResponse[json.RawMessage]{Data: json.RawMessage(data)})
+	}))
+	defer srv.Close()
+
+	client := New(WithBaseURL(srv.URL))
+	receipt, err := client.GetReceipt(context.Background(), "txn-001")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := map[int]int{767898: 171607, 823326: 231878, 552022: 121453, 999999: 0}
+	for _, item := range receipt.Items {
+		if got := item.WebshopID; got != want[item.ProductID] {
+			t.Errorf("ProductID %d: got WebshopID %d, want %d", item.ProductID, got, want[item.ProductID])
+		}
+	}
+}
+
+func TestConvertPOSIDsBatchShape(t *testing.T) {
+	var captured string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, raw := readGraphQLRequest(t, r)
+		captured = raw
+		json.NewEncoder(w).Encode(graphQLResponse[json.RawMessage]{
+			Data: json.RawMessage(`{"p0":171607,"p1":231878}`),
+		})
+	}))
+	defer srv.Close()
+
+	client := New(WithBaseURL(srv.URL))
+	// Includes a duplicate (767898 twice) and a non-positive id (0)
+	// that must both be filtered out before the request is built.
+	mapping, err := client.ConvertPOSIDs(context.Background(), []int{767898, 823326, 767898, 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if mapping[767898] != 171607 || mapping[823326] != 231878 {
+		t.Errorf("unexpected mapping: %v", mapping)
+	}
+
+	// Exactly two aliased subfields (one per unique positive id), in
+	// input order, no duplicates, no zero.
+	wantFragments := []string{
+		"p0: productConvertId(sourceId: 767898)",
+		"p1: productConvertId(sourceId: 823326)",
+	}
+	for _, f := range wantFragments {
+		if !strings.Contains(captured, f) {
+			t.Errorf("expected query to contain %q, got %s", f, captured)
+		}
+	}
+	if strings.Contains(captured, "p2:") {
+		t.Errorf("expected exactly 2 aliases, got %s", captured)
+	}
+	if strings.Contains(captured, "sourceId: 0") {
+		t.Errorf("zero id should have been filtered, got %s", captured)
+	}
+}
+
+func TestConvertPOSIDsErrorIsBestEffort(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req, _ := readGraphQLRequest(t, r)
+		if strings.Contains(req.Query, "posReceiptDetails") {
+			json.NewEncoder(w).Encode(graphQLResponse[json.RawMessage]{
+				Data: json.RawMessage(receiptDetailsFixture),
+			})
+			return
+		}
+		// Convert call fails — GetReceipt must still succeed.
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := New(WithBaseURL(srv.URL))
+	receipt, err := client.GetReceipt(context.Background(), "txn-001")
+	if err != nil {
+		t.Fatalf("GetReceipt should be best-effort, got error: %v", err)
+	}
+	if len(receipt.Items) != 4 {
+		t.Fatalf("got %d items, want 4", len(receipt.Items))
+	}
+	for _, item := range receipt.Items {
+		if item.WebshopID != 0 {
+			t.Errorf("expected WebshopID=0 on convert failure, got %d for ProductID %d", item.WebshopID, item.ProductID)
+		}
 	}
 }

--- a/receipts_test.go
+++ b/receipts_test.go
@@ -179,8 +179,10 @@ const receiptDetailsFixture = `{
 	}
 }`
 
-// readGraphQLRequest reads and rewinds the body so the handler can both
-// inspect and decode the request.
+// readGraphQLRequest reads the request body once and returns it both
+// decoded as a graphQLRequest and as the original raw string, so the
+// handler can switch on the query while still asserting on the wire form.
+// It does not rewind r.Body — callers must not read it again.
 func readGraphQLRequest(t *testing.T, r *http.Request) (graphQLRequest, string) {
 	t.Helper()
 	raw, err := io.ReadAll(r.Body)
@@ -272,6 +274,34 @@ func TestConvertPOSIDsBatchShape(t *testing.T) {
 	}
 }
 
+func TestConvertPOSIDsTreatsNullAsUnresolved(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		readGraphQLRequest(t, r)
+		// productConvertId is `Int` (nullable) in the schema. A null
+		// alias must not break the whole batch — it should fall back
+		// to the same "unresolved" path as -1.
+		json.NewEncoder(w).Encode(graphQLResponse[json.RawMessage]{
+			Data: json.RawMessage(`{"p0":171607,"p1":null,"p2":-1}`),
+		})
+	}))
+	defer srv.Close()
+
+	client := New(WithBaseURL(srv.URL))
+	mapping, err := client.ConvertPOSIDs(context.Background(), []int{767898, 111111, 222222})
+	if err != nil {
+		t.Fatalf("null alias should not produce an error, got: %v", err)
+	}
+	if mapping[767898] != 171607 {
+		t.Errorf("expected 767898 -> 171607, got %d", mapping[767898])
+	}
+	if _, ok := mapping[111111]; ok {
+		t.Errorf("null alias should be omitted from mapping, got %d", mapping[111111])
+	}
+	if _, ok := mapping[222222]; ok {
+		t.Errorf("-1 sentinel should be omitted from mapping, got %d", mapping[222222])
+	}
+}
+
 func TestConvertPOSIDsErrorIsBestEffort(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		req, _ := readGraphQLRequest(t, r)
@@ -298,5 +328,18 @@ func TestConvertPOSIDsErrorIsBestEffort(t *testing.T) {
 		if item.WebshopID != 0 {
 			t.Errorf("expected WebshopID=0 on convert failure, got %d for ProductID %d", item.WebshopID, item.ProductID)
 		}
+	}
+
+	// Direct caller of ConvertPOSIDs that ignores err must not panic
+	// or nil-deref on the returned map; it should be safely readable.
+	mapping, err := client.ConvertPOSIDs(context.Background(), []int{1, 2})
+	if err == nil {
+		t.Fatalf("expected error from failing convert call")
+	}
+	if mapping == nil {
+		t.Fatalf("ConvertPOSIDs returned nil map alongside error; should be non-nil for safe lookup")
+	}
+	if v := mapping[1]; v != 0 {
+		t.Errorf("expected 0 lookup on empty map, got %d", v)
 	}
 }

--- a/types.go
+++ b/types.go
@@ -299,8 +299,10 @@ type ReceiptItem struct {
 	// see WebshopID for the webshop equivalent.
 	ProductID int `json:"productId,omitempty"`
 	// WebshopID is the AH webshop product id (the "wi<id>" used on
-	// ah.nl), resolved from ProductID via productConvertId. 0 when
-	// resolution failed or the API returned its -1 sentinel.
+	// ah.nl), resolved from ProductID via productConvertId. The
+	// in-memory zero value 0 means resolution failed or the API
+	// returned its -1 sentinel; in JSON, 0 is omitted entirely
+	// (omitempty), so consumers should treat "absent" as "unresolved".
 	WebshopID int `json:"webshopId,omitempty"`
 }
 

--- a/types.go
+++ b/types.go
@@ -294,8 +294,14 @@ type ReceiptItem struct {
 	Amount float64 `json:"amount"`
 	// UnitPrice is the price per unit.
 	UnitPrice float64 `json:"unitPrice,omitempty"`
-	// ProductID is the webshop product ID if available.
+	// ProductID is the POS-side product id printed on the kassabon
+	// (PosReceiptProduct.id). It is NOT directly navigable on ah.nl;
+	// see WebshopID for the webshop equivalent.
 	ProductID int `json:"productId,omitempty"`
+	// WebshopID is the AH webshop product id (the "wi<id>" used on
+	// ah.nl), resolved from ProductID via productConvertId. 0 when
+	// resolution failed or the API returned its -1 sentinel.
+	WebshopID int `json:"webshopId,omitempty"`
 }
 
 // ReceiptDiscount represents a discount line on a receipt (e.g. KRAS bonus).


### PR DESCRIPTION
## Summary

Adds first-class POS → webshop product-id resolution to the receipts module. `Client.GetReceipt` now populates a new `ReceiptItem.WebshopID` so consumers can deep-link kassabon lines to ah.nl without an extra round-trip per item.

## Why

`PosReceiptProduct.externalIds` is declared in the GraphQL schema but is always `null` in production, so `ReceiptItem.ProductID` (the POS-side integer printed on the kassabon) currently has no way to be turned into a navigable webshop id. The two id spaces are distinct: `https://www.ah.nl/producten/product/wi767898` returns "Dit product bestaat niet (meer)" while the actual webshop id for that line is `171607` ("Coca-Cola Zero sugar zero caffeïne").

The official Appie iOS/Android app shows product cards on every kassabon line, so a resolver clearly exists. Probing the `Query` type surfaced `productConvertId(sourceId: Int!): Int` — a single-argument resolver that does exactly this. Verified empirically:

| POS productId | kassabon name | productConvertId | hydrated title |
|---|---|---|---|
| 767898 | COCA-COLA | 171607 | Coca-Cola Zero sugar zero caffeïne |
| 823326 | AH KWARK | 231878 | AH Magere kwark |
| 552022 | AH ZALMFILET | 121453 | AH Zalmfilet |

The resolver returns `-1` when no conversion exists (e.g. when the input is already a webshop id). It does **not** validate the source id space, so passing arbitrary integers can return real but unrelated webshop ids — only feed it ids that came from `PosReceiptProduct.id`. This caveat is captured in the `ConvertPOSIDs` doc comment and in `doc/albertheijn_api.md`.

## What changed

- `receipts.go` — new `Client.ConvertPOSIDs(ctx, []int) (map[int]int, error)` builds a single GraphQL doc with N aliased `productConvertId` subfields (so a whole receipt resolves in one round-trip), dedupes input, drops non-positive ids and the `-1` sentinel. `GetReceipt` calls it best-effort (logs on failure, returns the receipt regardless) and fills `Items[i].WebshopID`. `GetReceipts` (list view) is unchanged — it doesn't return per-product data.
- `types.go` — adds `ReceiptItem.WebshopID int`. Updates the `ProductID` doc comment to clarify it is the POS-side id, not the webshop id (the previous wording was misleading).
- `cmd/appie/receipt.go` — `appie receipt show` appends `wi<id>` next to each line when resolution succeeded; blank otherwise.
- `doc/albertheijn_api.md` — adds a row to the GraphQL ops table and a `#### productConvertId` subsection covering signature, sentinel, caveat, and the aliased-batch example.
- Tests — three new unit tests (`TestGetReceiptResolvesWebshopID`, `TestConvertPOSIDsBatchShape` with dedup verification, `TestConvertPOSIDsErrorIsBestEffort`) plus an integration assertion in `TestGetReceiptIntegration` that at least one item resolves and `GetProduct(WebshopID)` round-trips successfully.

## Heads-up: pre-existing build break under `-tags integration`

Independent of this PR, `main` currently fails to compile under `-tags integration`: commit 515edfe added `TestGetShoppingListItems` to both `shoppinglist_test.go` (no tag) and `appie_integration_test.go` (under `//go:build integration`). To run the integration suite locally I had to rename one of them; the rename is **not** included in this PR. Happy to send a separate one-line fix if useful.

## Test plan

- [x] `just test` passes (3 new unit tests + existing suite).
- [x] `go test -tags integration -run 'TestGetReceiptIntegration' ./...` passes against a real account; canonical receipt resolves all 8 lines.
- [x] `appie receipt show <id>` annotates every line with `wi<id>`.