### PR TITLE
feat: add appie product subcommand and fix nutrition basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ appie login
 appie search "pindakaas"
 appie search --bonus "kaas"           # only bonus products
 
+# Look up product(s) by webshop ID
+appie product 12345                    # tabular row
+appie product 12345 67890 11111        # tabular rows (missing IDs warned on stderr)
+appie product -d 12345                 # detailed view with nutrition
+appie product -d 12345 67890           # stacked detail views
+
 # Last-chance bargains (laatste kans koopjes)
 appie koopjes 3521GZ                  # by postal code
 

--- a/appie_test.go
+++ b/appie_test.go
@@ -392,9 +392,16 @@ func TestFetchNutritionalInfoMock(t *testing.T) {
 					"tradeItem": map[string]any{
 						"nutritions": []map[string]any{
 							{
+								"basisQuantity": "100.0 Gram",
 								"nutrients": []map[string]any{
 									{"type": "FAT", "name": "Fat", "value": "15.5 g"},
 									{"type": "PROTEIN", "name": "Protein", "value": "8.2 g"},
+								},
+							},
+							{
+								"basisQuantity": "30.0 Gram",
+								"nutrients": []map[string]any{
+									{"type": "FAT", "name": "Fat", "value": "4.7 g"},
 								},
 							},
 						},
@@ -413,14 +420,17 @@ func TestFetchNutritionalInfoMock(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(info) != 2 {
-		t.Fatalf("expected 2 nutrients, got %d", len(info))
+	if len(info) != 3 {
+		t.Fatalf("expected 3 nutrients, got %d", len(info))
 	}
 
-	if info[0].Name != "Fat" || info[0].Type != "FAT" || info[0].Value != "15.5 g" {
+	if info[0].Name != "Fat" || info[0].Type != "FAT" || info[0].Value != "15.5 g" || info[0].Per != "100.0 Gram" {
 		t.Errorf("unexpected first nutrient: %+v", info[0])
 	}
-	if info[1].Name != "Protein" || info[1].Type != "PROTEIN" || info[1].Value != "8.2 g" {
+	if info[1].Name != "Protein" || info[1].Type != "PROTEIN" || info[1].Value != "8.2 g" || info[1].Per != "100.0 Gram" {
 		t.Errorf("unexpected second nutrient: %+v", info[1])
+	}
+	if info[2].Name != "Fat" || info[2].Per != "30.0 Gram" {
+		t.Errorf("unexpected third nutrient (serving group): %+v", info[2])
 	}
 }

--- a/cmd/appie/main.go
+++ b/cmd/appie/main.go
@@ -19,6 +19,7 @@ var globalOpts struct {
 
 	Login   loginCommand        `command:"login" description:"Login to Albert Heijn"`
 	Search  searchCommand       `command:"search" description:"Search for products"`
+	Product productCommand      `command:"product" description:"Look up product(s) by webshop ID"`
 	Receipt receiptCommand      `command:"receipt" subcommands-optional:"true" description:"List recent receipts"`
 	Order   orderCommand        `command:"order" subcommands-optional:"true" description:"List open orders"`
 	List    shoppingListCommand `command:"list" subcommands-optional:"true" description:"Show shopping lists"`

--- a/cmd/appie/product.go
+++ b/cmd/appie/product.go
@@ -108,8 +108,24 @@ func printProductDetail(p *appie.Product) {
 	}
 	if len(p.NutritionalInfo) > 0 {
 		fmt.Println("\n  Nutrition:")
+		var lastPer string
+		headerPrinted := false
 		for _, n := range p.NutritionalInfo {
-			fmt.Printf("    %-30s %s\n", n.Name, n.Value)
+			if !headerPrinted || n.Per != lastPer {
+				if headerPrinted {
+					fmt.Println()
+				}
+				header := n.Per
+				if header == "" {
+					header = "(unspecified basis)"
+				} else {
+					header = "per " + header
+				}
+				fmt.Printf("    %s:\n", header)
+				lastPer = n.Per
+				headerPrinted = true
+			}
+			fmt.Printf("      %-30s %s\n", n.Name, n.Value)
 		}
 	}
 }

--- a/cmd/appie/product.go
+++ b/cmd/appie/product.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	appie "github.com/gwillem/appie-go"
+)
+
+type productCommand struct {
+	Args struct {
+		IDs []int `positional-arg-name:"id" required:"1"`
+	} `positional-args:"yes"`
+	Detail bool `short:"d" long:"detail" description:"Show full detail (incl. nutrition) for each product"`
+}
+
+func (cmd *productCommand) Execute(args []string) error {
+	ctx, client, err := orderSetup()
+	if err != nil {
+		return err
+	}
+
+	ids := cmd.Args.IDs
+
+	products, err := client.GetProductsByIDs(ctx, ids)
+	if err != nil {
+		return fmt.Errorf("get products failed: %w", err)
+	}
+
+	for _, id := range missingIDs(ids, products) {
+		fmt.Fprintf(os.Stderr, "warning: product %d not found\n", id)
+	}
+
+	if len(products) == 0 {
+		return fmt.Errorf("no products resolved")
+	}
+
+	if !cmd.Detail {
+		printProducts(products)
+		return nil
+	}
+
+	for i, p := range products {
+		if i > 0 {
+			fmt.Println()
+		}
+		full, err := client.GetProductFull(ctx, p.ID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: nutrition fetch for %d failed: %v\n", p.ID, err)
+			printProductDetail(&p)
+			continue
+		}
+		printProductDetail(full)
+	}
+	return nil
+}
+
+// missingIDs returns the input IDs that are not present in products.
+// Order matches the input order; duplicates in input are reported once each.
+func missingIDs(ids []int, products []appie.Product) []int {
+	got := make(map[int]struct{}, len(products))
+	for _, p := range products {
+		got[p.ID] = struct{}{}
+	}
+	var missing []int
+	for _, id := range ids {
+		if _, ok := got[id]; !ok {
+			missing = append(missing, id)
+		}
+	}
+	return missing
+}
+
+func printProductDetail(p *appie.Product) {
+	fmt.Printf("%s\n", p.Title)
+	if p.Brand != "" {
+		fmt.Printf("  Brand:       %s\n", p.Brand)
+	}
+	fmt.Printf("  ID:          %d\n", p.ID)
+	if p.UnitSize != "" {
+		fmt.Printf("  Unit size:   %s\n", p.UnitSize)
+	}
+	if p.Price.Was > 0 && p.Price.Was != p.Price.Now {
+		fmt.Printf("  Price:       €%.2f (was €%.2f)\n", p.Price.Now, p.Price.Was)
+	} else {
+		fmt.Printf("  Price:       €%.2f\n", p.Price.Now)
+	}
+	if p.UnitPriceDescription != "" {
+		fmt.Printf("  Unit price:  %s\n", p.UnitPriceDescription)
+	}
+	if p.BonusMechanism != "" {
+		fmt.Printf("  Bonus:       %s\n", p.BonusMechanism)
+	}
+	if p.Category != "" {
+		cat := p.Category
+		if p.SubCategory != "" {
+			cat += " / " + p.SubCategory
+		}
+		fmt.Printf("  Category:    %s\n", cat)
+	}
+	if p.NutriScore != "" {
+		fmt.Printf("  Nutri-Score: %s\n", p.NutriScore)
+	}
+	fmt.Printf("  Available:   %t\n", p.IsAvailable)
+	fmt.Printf("  Orderable:   %t\n", p.IsOrderable)
+	if p.ShortDescription != "" {
+		fmt.Printf("\n  %s\n", p.ShortDescription)
+	}
+	if len(p.NutritionalInfo) > 0 {
+		fmt.Println("\n  Nutrition:")
+		for _, n := range p.NutritionalInfo {
+			fmt.Printf("    %-30s %s\n", n.Name, n.Value)
+		}
+	}
+}

--- a/cmd/appie/product_test.go
+++ b/cmd/appie/product_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"slices"
+	"testing"
+
+	appie "github.com/gwillem/appie-go"
+)
+
+func TestMissingIDs(t *testing.T) {
+	tests := []struct {
+		name     string
+		ids      []int
+		products []appie.Product
+		want     []int
+	}{
+		{
+			name:     "all present",
+			ids:      []int{1, 2, 3},
+			products: []appie.Product{{ID: 1}, {ID: 2}, {ID: 3}},
+			want:     nil,
+		},
+		{
+			name:     "some missing",
+			ids:      []int{1, 2, 3, 4},
+			products: []appie.Product{{ID: 1}, {ID: 3}},
+			want:     []int{2, 4},
+		},
+		{
+			name:     "all missing",
+			ids:      []int{1, 2},
+			products: nil,
+			want:     []int{1, 2},
+		},
+		{
+			name:     "preserves input order",
+			ids:      []int{9, 5, 7},
+			products: []appie.Product{{ID: 5}},
+			want:     []int{9, 7},
+		},
+		{
+			name:     "duplicate input id reported each time",
+			ids:      []int{1, 1, 2},
+			products: []appie.Product{{ID: 2}},
+			want:     []int{1, 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := missingIDs(tt.ids, tt.products)
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/products.go
+++ b/products.go
@@ -46,6 +46,7 @@ const fetchProductNutritionQuery = `query FetchProduct($productId: Int!) {
     id
     tradeItem {
       nutritions {
+        basisQuantity
         nutrients {
           type
           name
@@ -61,7 +62,8 @@ type productNutritionResponse struct {
 		ID        int `json:"id"`
 		TradeItem *struct {
 			Nutritions []struct {
-				Nutrients []struct {
+				BasisQuantity string `json:"basisQuantity"`
+				Nutrients     []struct {
 					Type  string `json:"type"`
 					Name  string `json:"name"`
 					Value string `json:"value"`
@@ -165,6 +167,7 @@ func (c *Client) fetchNutritionalInfo(ctx context.Context, productID int) ([]Nut
 				Name:  n.Name,
 				Type:  n.Type,
 				Value: n.Value,
+				Per:   nutrition.BasisQuantity,
 			})
 		}
 	}

--- a/types.go
+++ b/types.go
@@ -26,6 +26,9 @@ type NutritionalInfo struct {
 	Type string `json:"type"`
 	// Value is the amount with unit (e.g., "15.5 g", "250 kcal").
 	Value string `json:"value"`
+	// Per is the basis the value applies to as reported by the API
+	// (e.g., "100.0 Gram", "15.0 Gram"). Empty if not provided.
+	Per string `json:"per,omitempty"`
 }
 
 // Product represents an AH product with pricing and availability information.


### PR DESCRIPTION
## Summary

- Adds `appie product <id> [<id>...]` CLI subcommand for looking up products by webshop ID. Defaults to a tabular row (matching `appie search`); `-d`/`--detail` switches to a stacked detail view with nutrition. Missing IDs warn to stderr; exit non-zero only if nothing resolves.
- Fixes nutrition basis: the GraphQL `basisQuantityDescription` field is unreliable — for some products it carries free-text serving info (e.g. "200 gram") rather than the basis the nutrient values apply to. The trustworthy field is `basisQuantity` (e.g. "100.0 Gram"). Switches the nutrition query and surfaces it on a new non-breaking `NutritionalInfo.Per` field.

## Test plan

- [x] `just test` passes
- [x] `appie product 96049` (potato, single group): renders "per 100.0 Gram" — values are 371 kJ / 88 kcal, correct per-100g.
- [x] `appie product -d 220739` (Calvé Pindakaas, two groups): renders both "per 100.0 Gram" and "per 15.0 Gram" groups distinctly.
- [x] `appie product 1 2 3 999999999`: warns missing IDs on stderr, prints tabular for the rest.
- [x] Existing nutrition mock test updated to assert `Per` field on both basis groups.