### PR TITLE
refactor: expose DefaultConfigPath, use XDG path in integration tests

### DIFF
--- a/appie_integration_test.go
+++ b/appie_integration_test.go
@@ -12,14 +12,14 @@ import (
 func testClient(t *testing.T) *Client {
 	t.Helper()
 
-	// Try to load from .appie.json
-	client, err := NewWithConfig(".appie.json")
+	configPath := DefaultConfigPath()
+	client, err := NewWithConfig(configPath)
 	if err != nil {
-		t.Skipf("failed to load config: %v", err)
+		t.Skipf("failed to load config from %s: %v", configPath, err)
 	}
 
 	if !client.IsAuthenticated() {
-		t.Skip("no authentication tokens available")
+		t.Skipf("no authentication tokens at %s; run `appie login`", configPath)
 	}
 
 	return client
@@ -145,7 +145,7 @@ func TestGetShoppingList(t *testing.T) {
 	}
 }
 
-func TestGetShoppingListItems(t *testing.T) {
+func TestGetShoppingListItemsIntegration(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/client.go
+++ b/client.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -101,6 +102,21 @@ func New(opts ...Option) *Client {
 	}
 
 	return c
+}
+
+// DefaultConfigPath returns the standard XDG config path for the appie config
+// file ($XDG_CONFIG_HOME/appie/config.json, falling back to ~/.config/appie/config.json).
+// If the user's home directory cannot be determined it returns ".appie.json" in cwd.
+func DefaultConfigPath() string {
+	dir := os.Getenv("XDG_CONFIG_HOME")
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ".appie.json"
+		}
+		dir = filepath.Join(home, ".config")
+	}
+	return filepath.Join(dir, "appie", "config.json")
 }
 
 // NewWithConfig creates a new client and loads config from the given path.

--- a/cmd/appie/main.go
+++ b/cmd/appie/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
 
 	appie "github.com/gwillem/appie-go"
 	"github.com/jessevdk/go-flags"
@@ -34,21 +33,9 @@ func clientOpts() []appie.Option {
 	return opts
 }
 
-func defaultConfigPath() string {
-	dir := os.Getenv("XDG_CONFIG_HOME")
-	if dir == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return ".appie.json"
-		}
-		dir = filepath.Join(home, ".config")
-	}
-	return filepath.Join(dir, "appie", "config.json")
-}
-
 func main() {
 	if globalOpts.Config == "" {
-		globalOpts.Config = defaultConfigPath()
+		globalOpts.Config = appie.DefaultConfigPath()
 	}
 
 	p := flags.NewParser(&globalOpts, flags.Default)


### PR DESCRIPTION
## Summary

- Promote `defaultConfigPath()` from `cmd/appie/main.go` to a public library function `appie.DefaultConfigPath()`. The CLI, library consumers, and the integration test now share one source of truth for the XDG config location (`\$XDG_CONFIG_HOME/appie/config.json`, falling back to `~/.config/appie/config.json`).
- `appie_integration_test.go`'s `testClient` helper previously hardcoded `.appie.json` in cwd, so `go test -tags integration` would fail with stale/missing tokens even when the actual `appie` CLI in the same shell worked fine. It now reads from `DefaultConfigPath()` and surfaces the path in skip messages so a future "no auth" diagnostic points at the right file.
- Rename `TestGetShoppingListItems` → `TestGetShoppingListItemsIntegration` in `appie_integration_test.go`. The previous name collided with the unit test of the same name in `shoppinglist_test.go:11`, which made the integration build fail to compile entirely (also flagged in PR #17's description).

## Test plan

- [x] `go test ./...` — unit tests pass
- [x] `go test -tags integration -run TestGetMember -v` — passes against a real account, loading tokens from `~/.config/appie/config.json` with no `.appie.json` in cwd